### PR TITLE
Slugify existing element IDs

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,8 @@
+# 1.0.1 - 2016-03-09
+
+- Slugify existing element ID to prevent spaces and invalid characters in paths.
+- Fix module main location.
+
 # 1.0.0 - 2016-02-23
 
 - Initial release.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "abagnale",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Forge unique IDs for Refract data structure elements",
   "main": "lib/abagnale.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "abagnale",
   "version": "1.0.0",
   "description": "Forge unique IDs for Refract data structure elements",
-  "main": "index.js",
+  "main": "lib/abagnale.js",
   "scripts": {
     "test": "peasant test",
     "cover": "peasant cover",

--- a/src/abagnale.js
+++ b/src/abagnale.js
@@ -92,11 +92,11 @@ class Abagnale {
 
     if (refract.meta) {
       if (refract.meta.id) {
-        newPath = [refract.meta.id];
+        newPath = [slug(refract.meta.id)];
       } else if (path.length === 0 && refract.meta.classes &&
                  refract.meta.classes.length === 1) {
         // This is the first item, and it has a class name, so we use that.
-        newPath = [refract.meta.classes[0]];
+        newPath = [slug(refract.meta.classes[0])];
       }
     }
 

--- a/test/output/references.json
+++ b/test/output/references.json
@@ -2,7 +2,7 @@
   {
     "element": "object",
     "meta": {
-      "id": "MyObject"
+      "id": "myobject"
     },
     "content": [
       {
@@ -12,18 +12,18 @@
             "element": "string",
             "content": "name",
             "meta": {
-              "id": "MyObject.name-key"
+              "id": "myobject.name-key"
             }
           },
           "value": {
             "element": "SpecialString",
             "meta": {
-              "id": "MyObject.name"
+              "id": "myobject.name"
             }
           }
         },
         "meta": {
-          "id": "MyObject.name-member"
+          "id": "myobject.name-member"
         }
       },
       {
@@ -37,14 +37,14 @@
   {
     "element": "string",
     "meta": {
-      "id": "SpecialString"
+      "id": "specialstring"
     },
     "content": "I am special"
   },
   {
     "element": "object",
     "meta": {
-      "id": "IncludedObject"
+      "id": "includedobject"
     },
     "content": [
       {
@@ -54,18 +54,18 @@
             "element": "string",
             "content": "address",
             "meta": {
-              "id": "IncludedObject.address-key"
+              "id": "includedobject.address-key"
             }
           },
           "value": {
             "element": "string",
             "meta": {
-              "id": "IncludedObject.address"
+              "id": "includedobject.address"
             }
           }
         },
         "meta": {
-          "id": "IncludedObject.address-member"
+          "id": "includedobject.address-member"
         }
       }
     ]


### PR DESCRIPTION
This fixes #2 and #3. Existing element IDs are now sluggified, so spaces and other special characters will get converted for the path.

cc @Baggz 