### PR TITLE
Implement URI fragment link relations and fix dereferencing

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+# 1.1.0 - 2016-03-10
+
+- Revert slugifying existing element IDs as this breaks dereferencing. Instead, we now produce a new link relation called `uri-fragment` with each element that is safe to use in a URL and is based on the element's ID. Note: going from a URI fragment to an element ID requires either a search through all element link relations or a pre-built mapping of URI fragments to elements.
+
 # 1.0.1 - 2016-03-09
 
 - Slugify existing element ID to prevent spaces and invalid characters in paths.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ A library to forge IDs for elements in [Refract](https://github.com/refractproje
 
 Abagnale attempts to give all elements within the structure a unique ID, even for elements it does not know. It accomplishes this by crawling the element contents and looking for structures that look like other elements.
 
-See the [test output](https://github.com/apiaryio/abagnale/tree/master/test/output) directory for examples of generated IDs.
+Along with unique IDs it also attempts to give each element a unique URI fragment that is safe to use in a URL and based on the element's unique ID. This can be found in a link relation called `uri-fragment`.
+
+See the [test output](https://github.com/apiaryio/abagnale/tree/master/test/output) directory for examples of generated IDs and URI fragments.
 
 It is named after [Frank Abagnale](https://en.wikipedia.org/wiki/Frank_Abagnale), one of the most notorious tricksters ever known. He forged several fake IDs, a pilots license with which he flew over a million miles, faked being a college professor, worked as a fake chief resident pediatrician, and worked in the Louisiana State Attorney General's office with a fake degree from Harvard before being caught.
 
@@ -37,9 +39,10 @@ instance.forge(input);
 ### Available Options
 The following options can be set:
 
-Name        | Description                       | Default
------------ | --------------------------------- | -------
-`separator` | Character to denote path segments | `.`
+Name           | Description                                        | Default
+-------------- | -------------------------------------------------- | -------
+`separator`    | Character to denote path segments                  | `.`
+`uriSeparator` | Character to denote path segments in URI fragments | `/`
 
 ### Notable Missing Features
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "abagnale",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Forge unique IDs for Refract data structure elements",
   "main": "lib/abagnale.js",
   "scripts": {

--- a/src/abagnale.js
+++ b/src/abagnale.js
@@ -1,7 +1,7 @@
 // A module to forge IDs for Refract elements.
 import slug from 'slug';
 
-slug.defaults.modes.pretty.lower = true;
+slug.defaults.mode = 'rfc3986';
 
 class Abagnale {
   constructor(options) {
@@ -13,6 +13,10 @@ class Abagnale {
 
     if (this.options.separator === undefined) {
       this.options.separator = '.';
+    }
+
+    if (this.options.uriSeparator === undefined) {
+      this.options.uriSeparator = '/';
     }
 
     this.cache = {};
@@ -92,11 +96,11 @@ class Abagnale {
 
     if (refract.meta) {
       if (refract.meta.id) {
-        newPath = [slug(refract.meta.id)];
+        newPath = [refract.meta.id];
       } else if (path.length === 0 && refract.meta.classes &&
                  refract.meta.classes.length === 1) {
         // This is the first item, and it has a class name, so we use that.
-        newPath = [slug(refract.meta.classes[0])];
+        newPath = [refract.meta.classes[0]];
       }
     }
 
@@ -118,6 +122,20 @@ class Abagnale {
     }
 
     refract.meta.id = this.idForElement(path, refract);
+
+    if (!refract.meta.links) {
+      refract.meta.links = [];
+    }
+
+    refract.meta.links.push({
+      element: 'link',
+      content: {
+        relation: 'uri-fragment',
+        href: refract.meta.id.split(this.options.separator)
+                             .map((item) => slug(item))
+                             .join(this.options.uriSeparator),
+      },
+    });
 
     // Array like content containing elements?
     if (refract.content && refract.content.length && refract.content[0].element) {

--- a/test/output/api.json
+++ b/test/output/api.json
@@ -6,7 +6,16 @@
         "api"
       ],
       "title": "My API",
-      "id": "api"
+      "id": "api",
+      "links": [
+        {
+          "element": "link",
+          "content": {
+            "relation": "uri-fragment",
+            "href": "api"
+          }
+        }
+      ]
     },
     "attributes": {
       "meta": [
@@ -38,14 +47,32 @@
             "resourceGroup"
           ],
           "title": "",
-          "id": "api.resourcegroup"
+          "id": "api.resourcegroup",
+          "links": [
+            {
+              "element": "link",
+              "content": {
+                "relation": "uri-fragment",
+                "href": "api/resourcegroup"
+              }
+            }
+          ]
         },
         "content": [
           {
             "element": "resource",
             "meta": {
               "title": "Frob",
-              "id": "api.resourcegroup.frob"
+              "id": "api.resourcegroup.frob",
+              "links": [
+                {
+                  "element": "link",
+                  "content": {
+                    "relation": "uri-fragment",
+                    "href": "api/resourcegroup/frob"
+                  }
+                }
+              ]
             },
             "attributes": {
               "href": "/frobs"
@@ -55,7 +82,16 @@
                 "element": "transition",
                 "meta": {
                   "title": "Get a frob",
-                  "id": "api.resourcegroup.frob.get-a-frob"
+                  "id": "api.resourcegroup.frob.get-a-frob",
+                  "links": [
+                    {
+                      "element": "link",
+                      "content": {
+                        "relation": "uri-fragment",
+                        "href": "api/resourcegroup/frob/get-a-frob"
+                      }
+                    }
+                  ]
                 },
                 "content": [
                   {
@@ -68,7 +104,16 @@
                         },
                         "content": [],
                         "meta": {
-                          "id": "api.resourcegroup.frob.get-a-frob.httptransaction.httprequest"
+                          "id": "api.resourcegroup.frob.get-a-frob.httptransaction.httprequest",
+                          "links": [
+                            {
+                              "element": "link",
+                              "content": {
+                                "relation": "uri-fragment",
+                                "href": "api/resourcegroup/frob/get-a-frob/httptransaction/httprequest"
+                              }
+                            }
+                          ]
                         }
                       },
                       {
@@ -90,29 +135,74 @@
                                         "element": "string",
                                         "content": "id",
                                         "meta": {
-                                          "id": "api.resourcegroup.frob.get-a-frob.httptransaction.httpresponse.datastructure.0.id-key"
+                                          "id": "api.resourcegroup.frob.get-a-frob.httptransaction.httpresponse.datastructure.0.id-key",
+                                          "links": [
+                                            {
+                                              "element": "link",
+                                              "content": {
+                                                "relation": "uri-fragment",
+                                                "href": "api/resourcegroup/frob/get-a-frob/httptransaction/httpresponse/datastructure/0/id-key"
+                                              }
+                                            }
+                                          ]
                                         }
                                       },
                                       "value": {
                                         "element": "string",
                                         "content": "123",
                                         "meta": {
-                                          "id": "api.resourcegroup.frob.get-a-frob.httptransaction.httpresponse.datastructure.0.id"
+                                          "id": "api.resourcegroup.frob.get-a-frob.httptransaction.httpresponse.datastructure.0.id",
+                                          "links": [
+                                            {
+                                              "element": "link",
+                                              "content": {
+                                                "relation": "uri-fragment",
+                                                "href": "api/resourcegroup/frob/get-a-frob/httptransaction/httpresponse/datastructure/0/id"
+                                              }
+                                            }
+                                          ]
                                         }
                                       }
                                     },
                                     "meta": {
-                                      "id": "api.resourcegroup.frob.get-a-frob.httptransaction.httpresponse.datastructure.0.id-member"
+                                      "id": "api.resourcegroup.frob.get-a-frob.httptransaction.httpresponse.datastructure.0.id-member",
+                                      "links": [
+                                        {
+                                          "element": "link",
+                                          "content": {
+                                            "relation": "uri-fragment",
+                                            "href": "api/resourcegroup/frob/get-a-frob/httptransaction/httpresponse/datastructure/0/id-member"
+                                          }
+                                        }
+                                      ]
                                     }
                                   }
                                 ],
                                 "meta": {
-                                  "id": "api.resourcegroup.frob.get-a-frob.httptransaction.httpresponse.datastructure.0"
+                                  "id": "api.resourcegroup.frob.get-a-frob.httptransaction.httpresponse.datastructure.0",
+                                  "links": [
+                                    {
+                                      "element": "link",
+                                      "content": {
+                                        "relation": "uri-fragment",
+                                        "href": "api/resourcegroup/frob/get-a-frob/httptransaction/httpresponse/datastructure/0"
+                                      }
+                                    }
+                                  ]
                                 }
                               }
                             ],
                             "meta": {
-                              "id": "api.resourcegroup.frob.get-a-frob.httptransaction.httpresponse.datastructure"
+                              "id": "api.resourcegroup.frob.get-a-frob.httptransaction.httpresponse.datastructure",
+                              "links": [
+                                {
+                                  "element": "link",
+                                  "content": {
+                                    "relation": "uri-fragment",
+                                    "href": "api/resourcegroup/frob/get-a-frob/httptransaction/httpresponse/datastructure"
+                                  }
+                                }
+                              ]
                             }
                           },
                           {
@@ -121,18 +211,45 @@
                               "classes": [
                                 "messageBodySchema"
                               ],
-                              "id": "api.resourcegroup.frob.get-a-frob.httptransaction.httpresponse.messagebodyschema"
+                              "id": "api.resourcegroup.frob.get-a-frob.httptransaction.httpresponse.messagebodyschema",
+                              "links": [
+                                {
+                                  "element": "link",
+                                  "content": {
+                                    "relation": "uri-fragment",
+                                    "href": "api/resourcegroup/frob/get-a-frob/httptransaction/httpresponse/messagebodyschema"
+                                  }
+                                }
+                              ]
                             },
                             "content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"id\": {\n      \"type\": \"string\"\n    }\n  }\n}"
                           }
                         ],
                         "meta": {
-                          "id": "api.resourcegroup.frob.get-a-frob.httptransaction.httpresponse"
+                          "id": "api.resourcegroup.frob.get-a-frob.httptransaction.httpresponse",
+                          "links": [
+                            {
+                              "element": "link",
+                              "content": {
+                                "relation": "uri-fragment",
+                                "href": "api/resourcegroup/frob/get-a-frob/httptransaction/httpresponse"
+                              }
+                            }
+                          ]
                         }
                       }
                     ],
                     "meta": {
-                      "id": "api.resourcegroup.frob.get-a-frob.httptransaction"
+                      "id": "api.resourcegroup.frob.get-a-frob.httptransaction",
+                      "links": [
+                        {
+                          "element": "link",
+                          "content": {
+                            "relation": "uri-fragment",
+                            "href": "api/resourcegroup/frob/get-a-frob/httptransaction"
+                          }
+                        }
+                      ]
                     }
                   }
                 ]

--- a/test/output/arrays.json
+++ b/test/output/arrays.json
@@ -5,7 +5,16 @@
       {
         "element": "string",
         "meta": {
-          "id": "array.0"
+          "id": "array.0",
+          "links": [
+            {
+              "element": "link",
+              "content": {
+                "relation": "uri-fragment",
+                "href": "array/0"
+              }
+            }
+          ]
         }
       },
       {
@@ -14,17 +23,44 @@
           {
             "element": "number",
             "meta": {
-              "id": "array.1.0"
+              "id": "array.1.0",
+              "links": [
+                {
+                  "element": "link",
+                  "content": {
+                    "relation": "uri-fragment",
+                    "href": "array/1/0"
+                  }
+                }
+              ]
             }
           }
         ],
         "meta": {
-          "id": "array.1"
+          "id": "array.1",
+          "links": [
+            {
+              "element": "link",
+              "content": {
+                "relation": "uri-fragment",
+                "href": "array/1"
+              }
+            }
+          ]
         }
       }
     ],
     "meta": {
-      "id": "array"
+      "id": "array",
+      "links": [
+        {
+          "element": "link",
+          "content": {
+            "relation": "uri-fragment",
+            "href": "array"
+          }
+        }
+      ]
     }
   }
 ]

--- a/test/output/objects.json
+++ b/test/output/objects.json
@@ -9,18 +9,45 @@
             "element": "string",
             "content": "name",
             "meta": {
-              "id": "object.name-key"
+              "id": "object.name-key",
+              "links": [
+                {
+                  "element": "link",
+                  "content": {
+                    "relation": "uri-fragment",
+                    "href": "object/name-key"
+                  }
+                }
+              ]
             }
           },
           "value": {
             "element": "string",
             "meta": {
-              "id": "object.name"
+              "id": "object.name",
+              "links": [
+                {
+                  "element": "link",
+                  "content": {
+                    "relation": "uri-fragment",
+                    "href": "object/name"
+                  }
+                }
+              ]
             }
           }
         },
         "meta": {
-          "id": "object.name-member"
+          "id": "object.name-member",
+          "links": [
+            {
+              "element": "link",
+              "content": {
+                "relation": "uri-fragment",
+                "href": "object/name-member"
+              }
+            }
+          ]
         }
       },
       {
@@ -30,7 +57,16 @@
             "element": "string",
             "content": "tags",
             "meta": {
-              "id": "object.tags-key"
+              "id": "object.tags-key",
+              "links": [
+                {
+                  "element": "link",
+                  "content": {
+                    "relation": "uri-fragment",
+                    "href": "object/tags-key"
+                  }
+                }
+              ]
             }
           },
           "value": {
@@ -46,18 +82,45 @@
                         "element": "string",
                         "content": "name",
                         "meta": {
-                          "id": "object.tags.0.name-key"
+                          "id": "object.tags.0.name-key",
+                          "links": [
+                            {
+                              "element": "link",
+                              "content": {
+                                "relation": "uri-fragment",
+                                "href": "object/tags/0/name-key"
+                              }
+                            }
+                          ]
                         }
                       },
                       "value": {
                         "element": "string",
                         "meta": {
-                          "id": "object.tags.0.name"
+                          "id": "object.tags.0.name",
+                          "links": [
+                            {
+                              "element": "link",
+                              "content": {
+                                "relation": "uri-fragment",
+                                "href": "object/tags/0/name"
+                              }
+                            }
+                          ]
                         }
                       }
                     },
                     "meta": {
-                      "id": "object.tags.0.name-member"
+                      "id": "object.tags.0.name-member",
+                      "links": [
+                        {
+                          "element": "link",
+                          "content": {
+                            "relation": "uri-fragment",
+                            "href": "object/tags/0/name-member"
+                          }
+                        }
+                      ]
                     }
                   },
                   {
@@ -67,38 +130,101 @@
                         "element": "string",
                         "content": "count",
                         "meta": {
-                          "id": "object.tags.0.count-key"
+                          "id": "object.tags.0.count-key",
+                          "links": [
+                            {
+                              "element": "link",
+                              "content": {
+                                "relation": "uri-fragment",
+                                "href": "object/tags/0/count-key"
+                              }
+                            }
+                          ]
                         }
                       },
                       "value": {
                         "element": "number",
                         "meta": {
-                          "id": "object.tags.0.count"
+                          "id": "object.tags.0.count",
+                          "links": [
+                            {
+                              "element": "link",
+                              "content": {
+                                "relation": "uri-fragment",
+                                "href": "object/tags/0/count"
+                              }
+                            }
+                          ]
                         }
                       }
                     },
                     "meta": {
-                      "id": "object.tags.0.count-member"
+                      "id": "object.tags.0.count-member",
+                      "links": [
+                        {
+                          "element": "link",
+                          "content": {
+                            "relation": "uri-fragment",
+                            "href": "object/tags/0/count-member"
+                          }
+                        }
+                      ]
                     }
                   }
                 ],
                 "meta": {
-                  "id": "object.tags.0"
+                  "id": "object.tags.0",
+                  "links": [
+                    {
+                      "element": "link",
+                      "content": {
+                        "relation": "uri-fragment",
+                        "href": "object/tags/0"
+                      }
+                    }
+                  ]
                 }
               }
             ],
             "meta": {
-              "id": "object.tags"
+              "id": "object.tags",
+              "links": [
+                {
+                  "element": "link",
+                  "content": {
+                    "relation": "uri-fragment",
+                    "href": "object/tags"
+                  }
+                }
+              ]
             }
           }
         },
         "meta": {
-          "id": "object.tags-member"
+          "id": "object.tags-member",
+          "links": [
+            {
+              "element": "link",
+              "content": {
+                "relation": "uri-fragment",
+                "href": "object/tags-member"
+              }
+            }
+          ]
         }
       }
     ],
     "meta": {
-      "id": "object"
+      "id": "object",
+      "links": [
+        {
+          "element": "link",
+          "content": {
+            "relation": "uri-fragment",
+            "href": "object"
+          }
+        }
+      ]
     }
   }
 ]

--- a/test/output/references.json
+++ b/test/output/references.json
@@ -2,7 +2,16 @@
   {
     "element": "object",
     "meta": {
-      "id": "myobject"
+      "id": "MyObject",
+      "links": [
+        {
+          "element": "link",
+          "content": {
+            "relation": "uri-fragment",
+            "href": "myobject"
+          }
+        }
+      ]
     },
     "content": [
       {
@@ -12,18 +21,45 @@
             "element": "string",
             "content": "name",
             "meta": {
-              "id": "myobject.name-key"
+              "id": "MyObject.name-key",
+              "links": [
+                {
+                  "element": "link",
+                  "content": {
+                    "relation": "uri-fragment",
+                    "href": "myobject/name-key"
+                  }
+                }
+              ]
             }
           },
           "value": {
             "element": "SpecialString",
             "meta": {
-              "id": "myobject.name"
+              "id": "MyObject.name",
+              "links": [
+                {
+                  "element": "link",
+                  "content": {
+                    "relation": "uri-fragment",
+                    "href": "myobject/name"
+                  }
+                }
+              ]
             }
           }
         },
         "meta": {
-          "id": "myobject.name-member"
+          "id": "MyObject.name-member",
+          "links": [
+            {
+              "element": "link",
+              "content": {
+                "relation": "uri-fragment",
+                "href": "myobject/name-member"
+              }
+            }
+          ]
         }
       },
       {
@@ -37,14 +73,32 @@
   {
     "element": "string",
     "meta": {
-      "id": "specialstring"
+      "id": "SpecialString",
+      "links": [
+        {
+          "element": "link",
+          "content": {
+            "relation": "uri-fragment",
+            "href": "specialstring"
+          }
+        }
+      ]
     },
     "content": "I am special"
   },
   {
     "element": "object",
     "meta": {
-      "id": "includedobject"
+      "id": "IncludedObject",
+      "links": [
+        {
+          "element": "link",
+          "content": {
+            "relation": "uri-fragment",
+            "href": "includedobject"
+          }
+        }
+      ]
     },
     "content": [
       {
@@ -54,18 +108,45 @@
             "element": "string",
             "content": "address",
             "meta": {
-              "id": "includedobject.address-key"
+              "id": "IncludedObject.address-key",
+              "links": [
+                {
+                  "element": "link",
+                  "content": {
+                    "relation": "uri-fragment",
+                    "href": "includedobject/address-key"
+                  }
+                }
+              ]
             }
           },
           "value": {
             "element": "string",
             "meta": {
-              "id": "includedobject.address"
+              "id": "IncludedObject.address",
+              "links": [
+                {
+                  "element": "link",
+                  "content": {
+                    "relation": "uri-fragment",
+                    "href": "includedobject/address"
+                  }
+                }
+              ]
             }
           }
         },
         "meta": {
-          "id": "includedobject.address-member"
+          "id": "IncludedObject.address-member",
+          "links": [
+            {
+              "element": "link",
+              "content": {
+                "relation": "uri-fragment",
+                "href": "includedobject/address-member"
+              }
+            }
+          ]
         }
       }
     ]

--- a/test/output/simple-types.json
+++ b/test/output/simple-types.json
@@ -3,35 +3,80 @@
     "element": "boolean",
     "content": true,
     "meta": {
-      "id": "boolean"
+      "id": "boolean",
+      "links": [
+        {
+          "element": "link",
+          "content": {
+            "relation": "uri-fragment",
+            "href": "boolean"
+          }
+        }
+      ]
     }
   },
   {
     "element": "string",
     "content": "test",
     "meta": {
-      "id": "string"
+      "id": "string",
+      "links": [
+        {
+          "element": "link",
+          "content": {
+            "relation": "uri-fragment",
+            "href": "string"
+          }
+        }
+      ]
     }
   },
   {
     "element": "string",
     "content": "another test",
     "meta": {
-      "id": "string-2"
+      "id": "string-2",
+      "links": [
+        {
+          "element": "link",
+          "content": {
+            "relation": "uri-fragment",
+            "href": "string-2"
+          }
+        }
+      ]
     }
   },
   {
     "element": "number",
     "content": 123,
     "meta": {
-      "id": "number"
+      "id": "number",
+      "links": [
+        {
+          "element": "link",
+          "content": {
+            "relation": "uri-fragment",
+            "href": "number"
+          }
+        }
+      ]
     }
   },
   {
     "element": "number",
     "content": 456,
     "meta": {
-      "id": "number-2"
+      "id": "number-2",
+      "links": [
+        {
+          "element": "link",
+          "content": {
+            "relation": "uri-fragment",
+            "href": "number-2"
+          }
+        }
+      ]
     }
   }
 ]


### PR DESCRIPTION
This fixes the bug introduced with the 1.0.1 release, as well as adding in the new link relation `uri-fragment` which contains the unique URL-safe ID as its `href` value. E.g.

```js
let element = {
  element: 'string',
  meta: {
    id: 'My Special String'
  },
  content: 'Hello!'
};

abagnale.forge(element);

console.log(element.meta.id);
// => My Special String
console.log(element.meta.links[0].href);
// => my-special-string
```

Obviously you shouldn't assume `links[0]` but you get the idea! :smile: Object members get separated by `/` instead of `.` for the URI fragment, so you get pieces like `my-object/member-name`. Both separator types are configurable and the README is updated to reflect that.

cc @Baggz 