### PR TITLE
Add tests for bad input data, add safeSlug function

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+# 1.1.1 - 2016-04-20
+
+- Prevent crashing due to some bad inputs that could not be sluggified.
+
 # 1.1.0 - 2016-03-10
 
 - Revert slugifying existing element IDs as this breaks dereferencing. Instead, we now produce a new link relation called `uri-fragment` with each element that is safe to use in a URL and is based on the element's ID. Note: going from a URI fragment to an element ID requires either a search through all element link relations or a pre-built mapping of URI fragments to elements.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "abagnale",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Forge unique IDs for Refract data structure elements",
   "main": "lib/abagnale.js",
   "scripts": {

--- a/src/abagnale.js
+++ b/src/abagnale.js
@@ -3,6 +3,20 @@ import slug from 'slug';
 
 slug.defaults.mode = 'rfc3986';
 
+// A safe way to slugify values. If the input is null, undefined, or
+// some other error happens downstream, we simply return `unknown`.
+function safeSlug(value) {
+  let sluggified;
+
+  try {
+    sluggified = slug(value);
+  } catch (err) {
+    sluggified = 'unknown';
+  }
+
+  return sluggified;
+}
+
 class Abagnale {
   constructor(options) {
     this.options = options;
@@ -64,22 +78,22 @@ class Abagnale {
       break;
     default:
       // Non-basic types default to the element name, e.g. `resource`.
-      key = slug(refract.element);
+      key = safeSlug(refract.element);
     }
 
     // If this is a member and the key is a string, use the key value.
     if (refract.content && refract.content.key &&
         refract.content.key.element === 'string') {
-      key = slug(refract.content.key.content);
+      key = safeSlug(refract.content.key.content);
     }
 
     // If there is a title or a *single* class name, use that instead as it
     // should contain more specific and relevant information.
     if (refract.meta) {
       if (refract.meta.title) {
-        key = slug(refract.meta.title);
+        key = safeSlug(refract.meta.title);
       } else if (refract.meta.classes && refract.meta.classes.length === 1) {
-        key = slug(refract.meta.classes[0]);
+        key = safeSlug(refract.meta.classes[0]);
       }
     }
 
@@ -117,6 +131,10 @@ class Abagnale {
     Forge an ID for a single refract structure and any children in-place.
   */
   forgeOne(path, refract) {
+    if (!refract) {
+      return refract;
+    }
+
     if (!refract.meta) {
       refract.meta = {};
     }
@@ -132,7 +150,7 @@ class Abagnale {
       content: {
         relation: 'uri-fragment',
         href: refract.meta.id.split(this.options.separator)
-                             .map((item) => slug(item))
+                             .map((item) => safeSlug(item))
                              .join(this.options.uriSeparator),
       },
     });

--- a/src/abagnale.js
+++ b/src/abagnale.js
@@ -145,15 +145,17 @@ class Abagnale {
       refract.meta.links = [];
     }
 
-    refract.meta.links.push({
-      element: 'link',
-      content: {
-        relation: 'uri-fragment',
-        href: refract.meta.id.split(this.options.separator)
-                             .map((item) => safeSlug(item))
-                             .join(this.options.uriSeparator),
-      },
-    });
+    if (refract.meta.id && refract.meta.id.split) {
+      refract.meta.links.push({
+        element: 'link',
+        content: {
+          relation: 'uri-fragment',
+          href: refract.meta.id.split(this.options.separator)
+                               .map((item) => safeSlug(item))
+                               .join(this.options.uriSeparator),
+        },
+      });
+    }
 
     // Array like content containing elements?
     if (refract.content && refract.content.length && refract.content[0].element) {

--- a/test/abagnale.js
+++ b/test/abagnale.js
@@ -4,6 +4,38 @@ import fs from 'fs';
 import glob from 'glob';
 import path from 'path';
 
+describe('Bad refract input data', () => {
+  it('should not crash', () => {
+    const input = [{
+      element: 'array',
+      content: [
+        {
+          element: 'member',
+          content: {
+            key: {
+              element: 'string',
+            },
+          },
+        },
+        {
+          content: 'missing-element',
+        },
+        {
+          element: 'string',
+          meta: {
+            classes: [null],
+          },
+        },
+      ],
+    }];
+
+    // This test will pass so long as no errors are thrown.
+    abagnale.forge(input, {
+      separator: '.',
+    });
+  });
+});
+
 describe('Test fixtures match expected output', () => {
   glob.sync('./test/input/*.json').forEach((filename) => {
     it(path.basename(filename, '.json'), () => {

--- a/test/abagnale.js
+++ b/test/abagnale.js
@@ -5,9 +5,9 @@ import glob from 'glob';
 import path from 'path';
 
 describe('Bad refract input data', () => {
-  it('should not crash', () => {
+  it('should handle member missing a value', () => {
     const input = [{
-      element: 'array',
+      element: 'object',
       content: [
         {
           element: 'member',
@@ -17,16 +17,51 @@ describe('Bad refract input data', () => {
             },
           },
         },
+      ],
+    }];
+
+    // This test will pass so long as no errors are thrown.
+    abagnale.forge(input, {
+      separator: '.',
+    });
+  });
+
+  it('should handle missing element', () => {
+    const input = [{
+      element: 'array',
+      content: [
+        {
+          element: 'string',
+        },
         {
           content: 'missing-element',
         },
-        {
-          element: 'string',
-          meta: {
-            classes: [null],
-          },
-        },
       ],
+    }];
+
+    // This test will pass so long as no errors are thrown.
+    abagnale.forge(input, {
+      separator: '.',
+    });
+  });
+
+  it('should handle non-string in classes', () => {
+    const input = [{
+      element: 'string',
+      meta: {
+        classes: [null],
+      },
+    }];
+
+    // This test will pass so long as no errors are thrown.
+    abagnale.forge(input, {
+      separator: '.',
+    });
+  });
+
+  it('should handle non-string in element name', () => {
+    const input = [{
+      element: null,
     }];
 
     // This test will pass so long as no errors are thrown.


### PR DESCRIPTION
This fixes a couple different crashes due to bad input data, where the `slug` implementation would throw an error while converting to a string. This should prevent any crashing in Abagnale, but if bad data exists it may affect other downstream tools as well.

If the slug function ever fails it will generate unique names with an `'unknown'` component, e.g. `object.unknown-member` or `array.unknown-2.member-value.string`. This should never happen, but if it does we need to return something unique for the ID.

cc @Baggz 