### PR TITLE
Remove slug/unicode

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+# 1.1.2 - 2016-10-27
+
+- Remove `slug` dependency and replace it with `encodeURIComponent`. `slug` was including whole Unicode into final build.
+
 # 1.1.1 - 2016-04-20
 
 - Prevent crashing due to some bad inputs that could not be sluggified.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "abagnale",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Forge unique IDs for Refract data structure elements",
   "main": "lib/abagnale.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "peasant": "^0.5.2"
   },
   "dependencies": {
-    "babel-runtime": "^5.0.0",
-    "slug": "^0.9.1"
+    "babel-runtime": "^5.0.0"
   }
 }

--- a/src/abagnale.js
+++ b/src/abagnale.js
@@ -1,7 +1,10 @@
 // A safe way to slugify values. If the input is null, undefined, or
 // some other error happens downstream, we simply return `unknown`.
-function safeSlug(value) {
-  return encodeURIComponent(value).toLowerCase().replace(/[!'()*]/g, x => `%${x.charCodeAt(0).toString(16)}`).replace(/%20|%2520/g, '-') || 'unknown';
+function safeSlug(value = 'unknown') {
+  return encodeURIComponent(value)
+  .toLowerCase()
+  .replace(/[!'()*]/g, x => `%${x.charCodeAt(0).toString(16)}`) // RFC 3986 & https://developer.mozilla.org/cs/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent
+  .replace(/%20|%2520/g, '-'); // Swap (encoded) spaces for hyphens
 }
 
 class Abagnale {

--- a/src/abagnale.js
+++ b/src/abagnale.js
@@ -1,20 +1,7 @@
-// A module to forge IDs for Refract elements.
-import slug from 'slug';
-
-slug.defaults.mode = 'rfc3986';
-
 // A safe way to slugify values. If the input is null, undefined, or
 // some other error happens downstream, we simply return `unknown`.
 function safeSlug(value) {
-  let sluggified;
-
-  try {
-    sluggified = slug(value);
-  } catch (err) {
-    sluggified = 'unknown';
-  }
-
-  return sluggified;
+  return encodeURIComponent(value).toLowerCase().replace(/[!'()*]/g, x => `%${x.charCodeAt(0).toString(16)}`).replace(/%20|%2520/g, '-') || 'unknown';
 }
 
 class Abagnale {

--- a/test/abagnale.js
+++ b/test/abagnale.js
@@ -86,7 +86,7 @@ describe('Test fixtures match expected output', () => {
         output = generated;
       }
 
-      assert.deepEqual(output, generated);
+      assert.deepEqual(generated, output);
     });
   });
 });


### PR DESCRIPTION
This PR drops https://github.com/dodo/node-slug so we don't download full Unicode onto Apiary frontend.

