### PR TITLE
Add support for expanded Refract serialisation

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@
 - Support generating an element ID from a Refracted classes.
 - Element IDs will *always* be Refracted elements.
 - Any meta or attributes attached to existing element IDs will no longer be removed.
+- Adds support for elements which have existing links meta values that are array elements.
 
 # 1.1.3 - 2017-03-17
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,4 @@
-# Master
+# 2.0.0
 
 ## Bug Fixes
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,10 @@
 - Adds support for elements which have existing links meta values that are array elements.
 - Produced links meta will now *always* be an Array Element instead of direct
   array.
+- Link elements are now correctly formed. Previously the `href` and `relation`
+  was incorrectly placed in the elements content as an object.
+  [#9](https://github.com/apiaryio/abagnale/issues/9)
+
 
 # 1.1.3 - 2017-03-17
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,8 @@
 - Element IDs will *always* be Refracted elements.
 - Any meta or attributes attached to existing element IDs will no longer be removed.
 - Adds support for elements which have existing links meta values that are array elements.
+- Produced links meta will now *always* be an Array Element instead of direct
+  array.
 
 # 1.1.3 - 2017-03-17
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@
 
 - Support generating an element ID from a Refracted classes.
 - Element IDs will *always* be Refracted elements.
+- Any meta or attributes attached to existing element IDs will no longer be removed.
 
 # 1.1.3 - 2017-03-17
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,9 @@
+# Master
+
+## Bug Fixes
+
+- Support generating an element ID from a Refracted classes.
+
 # 1.1.3 - 2017-03-17
 
 ## Bug Fixes

--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 ## Bug Fixes
 
 - Support generating an element ID from a Refracted classes.
+- Element IDs will *always* be Refracted elements.
 
 # 1.1.3 - 2017-03-17
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "abagnale",
-  "version": "1.1.3",
+  "version": "2.0.0",
   "description": "Forge unique IDs for Refract data structure elements",
   "main": "lib/abagnale.js",
   "scripts": {

--- a/src/abagnale.js
+++ b/src/abagnale.js
@@ -105,10 +105,20 @@ class Abagnale {
         } else {
           newPath = [refract.meta.id];
         }
-      } else if (path.length === 0 && refract.meta.classes &&
-                 refract.meta.classes.length === 1) {
-        // This is the first item, and it has a class name, so we use that.
-        newPath = [refract.meta.classes[0]];
+      } else if (path.length === 0 && refract.meta.classes) {
+        const classes = refract.meta.classes;
+
+        if (classes.content && classes.content.length === 1) {
+          const klass = classes.content[0];
+
+          if (klass.element) {
+            newPath = [refract.meta.classes.content[0].content];
+          } else {
+            newPath = [refract.meta.classes.content[0]];
+          }
+        } else if (classes.element === undefined && classes.length === 1) {
+          newPath = [refract.meta.classes[0]];
+        }
       }
     }
 

--- a/src/abagnale.js
+++ b/src/abagnale.js
@@ -93,9 +93,9 @@ class Abagnale {
   /*
     Get an ID for an element, based on the current path, any existing ID,
     and any element class name. An existing ID will trump other values and
-    resets the path. Returns the unique ID to use.
+    resets the path. Returns the unique ID element to use.
   */
-  idForElement(path, refract) {
+  idElementForElement(path, refract) {
     let newPath = path;
 
     if (refract.meta) {
@@ -128,7 +128,12 @@ class Abagnale {
       id = refract.element;
     }
 
-    return this.getUnique(id);
+    const uniqueId = this.getUnique(id);
+
+    return {
+      element: 'string',
+      content: uniqueId
+    };
   }
 
   /*
@@ -143,18 +148,18 @@ class Abagnale {
       refract.meta = {};
     }
 
-    refract.meta.id = this.idForElement(path, refract);
+    refract.meta.id = this.idElementForElement(path, refract);
 
     if (!refract.meta.links) {
       refract.meta.links = [];
     }
 
-    if (refract.meta.id && refract.meta.id.split) {
+    if (refract.meta.id && refract.meta.id.content && refract.meta.id.content.split) {
       refract.meta.links.push({
         element: 'link',
         content: {
           relation: 'uri-fragment',
-          href: refract.meta.id.split(this.options.separator)
+          href: refract.meta.id.content.split(this.options.separator)
                                .map((item) => safeSlug(item))
                                .join(this.options.uriSeparator),
         },
@@ -166,7 +171,7 @@ class Abagnale {
       for (let i = 0; i < refract.content.length; i++) {
         const item = refract.content[i];
         const key = this.keyForArray(i, item);
-        const newPath = [refract.meta.id, key].join(this.options.separator);
+        const newPath = [refract.meta.id.content, key].join(this.options.separator);
 
         switch (item.element) {
         case 'ref':

--- a/src/abagnale.js
+++ b/src/abagnale.js
@@ -103,13 +103,14 @@ class Abagnale {
         if (typeof refract.meta.id === 'object') {
           this.getUnique(refract.meta.id.content);
           return refract.meta.id;
-        } else {
-          this.getUnique(refract.meta.id);
-          return {
-            element: 'string',
-            content: refract.meta.id
-          };
         }
+
+        this.getUnique(refract.meta.id);
+
+        return {
+          element: 'string',
+          content: refract.meta.id,
+        };
       } else if (path.length === 0 && refract.meta.classes) {
         const classes = refract.meta.classes;
 
@@ -137,7 +138,7 @@ class Abagnale {
 
     return {
       element: 'string',
-      content: uniqueId
+      content: uniqueId,
     };
   }
 
@@ -157,7 +158,7 @@ class Abagnale {
 
     if (!refract.meta.links) {
       refract.meta.links = {
-        element: 'array'
+        element: 'array',
       };
     }
 

--- a/src/abagnale.js
+++ b/src/abagnale.js
@@ -160,7 +160,7 @@ class Abagnale {
     }
 
     if (refract.meta.id && refract.meta.id.content && refract.meta.id.content.split) {
-      refract.meta.links.push({
+      const link = {
         element: 'link',
         content: {
           relation: 'uri-fragment',
@@ -168,7 +168,17 @@ class Abagnale {
                                .map((item) => safeSlug(item))
                                .join(this.options.uriSeparator),
         },
-      });
+      };
+
+      if (refract.meta.links.element !== undefined) {
+        if (!refract.meta.links.content) {
+          refract.meta.links.content = [];
+        }
+
+        refract.meta.links.content.push(link);
+      } else {
+        refract.meta.links.push(link);
+      }
     }
 
     // Array like content containing elements?

--- a/src/abagnale.js
+++ b/src/abagnale.js
@@ -156,7 +156,9 @@ class Abagnale {
     refract.meta.id = this.idElementForElement(path, refract);
 
     if (!refract.meta.links) {
-      refract.meta.links = [];
+      refract.meta.links = {
+        element: 'array'
+      };
     }
 
     if (refract.meta.id && refract.meta.id.content && refract.meta.id.content.split) {

--- a/src/abagnale.js
+++ b/src/abagnale.js
@@ -164,7 +164,7 @@ class Abagnale {
     if (refract.meta.id && refract.meta.id.content && refract.meta.id.content.split) {
       const link = {
         element: 'link',
-        content: {
+        attributes: {
           relation: 'uri-fragment',
           href: refract.meta.id.content.split(this.options.separator)
                                .map((item) => safeSlug(item))

--- a/src/abagnale.js
+++ b/src/abagnale.js
@@ -101,9 +101,14 @@ class Abagnale {
     if (refract.meta) {
       if (refract.meta.id) {
         if (typeof refract.meta.id === 'object') {
-          newPath = [refract.meta.id.content];
+          this.getUnique(refract.meta.id.content);
+          return refract.meta.id;
         } else {
-          newPath = [refract.meta.id];
+          this.getUnique(refract.meta.id);
+          return {
+            element: 'string',
+            content: refract.meta.id
+          };
         }
       } else if (path.length === 0 && refract.meta.classes) {
         const classes = refract.meta.classes;

--- a/test/abagnale.js
+++ b/test/abagnale.js
@@ -71,6 +71,97 @@ describe('Bad refract input data', () => {
   });
 });
 
+describe('Creating element IDs', () => {
+  it('should leave existing unrefracted ID unmodified', () => {
+    const input = [{
+      element: 'annotation',
+      meta: {
+        id: 'exampleID'
+      },
+      content: 'There is some problem.'
+    }];
+
+    const output = abagnale.forge(input);
+
+    assert.deepEqual(output, [{
+      element: 'annotation',
+      meta: {
+        id: 'exampleID',
+        links: [
+          {
+            element: 'link',
+            content: {
+              href: 'exampleid',
+              relation: 'uri-fragment'
+            }
+          }
+        ]
+      },
+      content: 'There is some problem.'
+    }]);
+  });
+
+  it('should generate ID from element name', () => {
+    const input = [{
+      element: 'annotation',
+      content: 'There is some problem.'
+    }];
+
+    const output = abagnale.forge(input);
+
+    assert.deepEqual(output, [{
+      element: 'annotation',
+      meta: {
+        id: 'annotation',
+        links: [
+          {
+            element: 'link',
+            content: {
+              href: 'annotation',
+              relation: 'uri-fragment'
+            }
+          }
+        ]
+      },
+      content: 'There is some problem.'
+    }]);
+  });
+
+  it('should generate ID from first unrefracted class', () => {
+    const input = [{
+      element: 'annotation',
+      meta: {
+        classes: [
+          'warning'
+        ]
+      },
+      content: 'There is some problem.'
+    }];
+
+    const output = abagnale.forge(input);
+
+    assert.deepEqual(output, [{
+      element: 'annotation',
+      meta: {
+        id: 'warning',
+        classes: [
+          'warning'
+        ],
+        links: [
+          {
+            element: 'link',
+            content: {
+              href: 'warning',
+              relation: 'uri-fragment'
+            }
+          }
+        ]
+      },
+      content: 'There is some problem.'
+    }]);
+  });
+});
+
 describe('Test fixtures match expected output', () => {
   glob.sync('./test/input/*.json').forEach((filename) => {
     it(path.basename(filename, '.json'), () => {

--- a/test/abagnale.js
+++ b/test/abagnale.js
@@ -76,9 +76,9 @@ describe('Creating element IDs', () => {
     const input = [{
       element: 'annotation',
       meta: {
-        id: 'exampleID'
+        id: 'exampleID',
       },
-      content: 'There is some problem.'
+      content: 'There is some problem.',
     }];
 
     const output = abagnale.forge(input);
@@ -88,7 +88,7 @@ describe('Creating element IDs', () => {
       meta: {
         id: {
           element: 'string',
-          content: 'exampleID'
+          content: 'exampleID',
         },
         links: {
           element: 'array',
@@ -97,13 +97,13 @@ describe('Creating element IDs', () => {
               element: 'link',
               attributes: {
                 href: 'exampleid',
-                relation: 'uri-fragment'
-              }
-            }
-          ]
-        }
+                relation: 'uri-fragment',
+              },
+            },
+          ],
+        },
       },
-      content: 'There is some problem.'
+      content: 'There is some problem.',
     }]);
   });
 
@@ -116,13 +116,13 @@ describe('Creating element IDs', () => {
           attributes: {
             attr: {
               element: 'string',
-              content: 'Example'
-            }
+              content: 'Example',
+            },
           },
-          content: 'exampleID'
-        }
+          content: 'exampleID',
+        },
       },
-      content: 'There is some problem.'
+      content: 'There is some problem.',
     }];
 
     const output = abagnale.forge(input);
@@ -135,10 +135,10 @@ describe('Creating element IDs', () => {
           attributes: {
             attr: {
               element: 'string',
-              content: 'Example'
-            }
+              content: 'Example',
+            },
           },
-          content: 'exampleID'
+          content: 'exampleID',
         },
         links: {
           element: 'array',
@@ -147,20 +147,20 @@ describe('Creating element IDs', () => {
               element: 'link',
               attributes: {
                 href: 'exampleid',
-                relation: 'uri-fragment'
-              }
-            }
-          ]
-        }
+                relation: 'uri-fragment',
+              },
+            },
+          ],
+        },
       },
-      content: 'There is some problem.'
+      content: 'There is some problem.',
     }]);
   });
 
   it('should generate ID from element name', () => {
     const input = [{
       element: 'annotation',
-      content: 'There is some problem.'
+      content: 'There is some problem.',
     }];
 
     const output = abagnale.forge(input);
@@ -170,7 +170,7 @@ describe('Creating element IDs', () => {
       meta: {
         id: {
           element: 'string',
-          content: 'annotation'
+          content: 'annotation',
         },
         links: {
           element: 'array',
@@ -179,13 +179,13 @@ describe('Creating element IDs', () => {
               element: 'link',
               attributes: {
                 href: 'annotation',
-                relation: 'uri-fragment'
-              }
-            }
-          ]
-        }
+                relation: 'uri-fragment',
+              },
+            },
+          ],
+        },
       },
-      content: 'There is some problem.'
+      content: 'There is some problem.',
     }]);
   });
 
@@ -194,10 +194,10 @@ describe('Creating element IDs', () => {
       element: 'annotation',
       meta: {
         classes: [
-          'warning'
-        ]
+          'warning',
+        ],
       },
-      content: 'There is some problem.'
+      content: 'There is some problem.',
     }];
 
     const output = abagnale.forge(input);
@@ -207,10 +207,10 @@ describe('Creating element IDs', () => {
       meta: {
         id: {
           element: 'string',
-          content: 'warning'
+          content: 'warning',
         },
         classes: [
-          'warning'
+          'warning',
         ],
         links: {
           element: 'array',
@@ -219,13 +219,13 @@ describe('Creating element IDs', () => {
               element: 'link',
               attributes: {
                 href: 'warning',
-                relation: 'uri-fragment'
-              }
-            }
-          ]
-        }
+                relation: 'uri-fragment',
+              },
+            },
+          ],
+        },
       },
-      content: 'There is some problem.'
+      content: 'There is some problem.',
     }]);
   });
 
@@ -238,12 +238,12 @@ describe('Creating element IDs', () => {
           content: [
             {
               element: 'string',
-              content: 'warning'
-            }
-          ]
-        }
+              content: 'warning',
+            },
+          ],
+        },
       },
-      content: 'There is some problem.'
+      content: 'There is some problem.',
     }];
 
     const output = abagnale.forge(input);
@@ -253,16 +253,16 @@ describe('Creating element IDs', () => {
       meta: {
         id: {
           element: 'string',
-          content: 'warning'
+          content: 'warning',
         },
         classes: {
           element: 'array',
           content: [
             {
               element: 'string',
-              content: 'warning'
-            }
-          ]
+              content: 'warning',
+            },
+          ],
         },
         links: {
           element: 'array',
@@ -271,13 +271,13 @@ describe('Creating element IDs', () => {
               element: 'link',
               attributes: {
                 href: 'warning',
-                relation: 'uri-fragment'
-              }
-            }
-          ]
-        }
+                relation: 'uri-fragment',
+              },
+            },
+          ],
+        },
       },
-      content: 'There is some problem.'
+      content: 'There is some problem.',
     }]);
   });
 
@@ -287,10 +287,10 @@ describe('Creating element IDs', () => {
       meta: {
         id: {
           element: 'string',
-          content: 'exampleID'
-        }
+          content: 'exampleID',
+        },
       },
-      content: 'There is some problem.'
+      content: 'There is some problem.',
     }];
 
     const output = abagnale.forge(input);
@@ -300,7 +300,7 @@ describe('Creating element IDs', () => {
       meta: {
         id: {
           element: 'string',
-          content: 'exampleID'
+          content: 'exampleID',
         },
         links: {
           element: 'array',
@@ -309,13 +309,13 @@ describe('Creating element IDs', () => {
               element: 'link',
               attributes: {
                 href: 'exampleid',
-                relation: 'uri-fragment'
-              }
-            }
-          ]
-        }
+                relation: 'uri-fragment',
+              },
+            },
+          ],
+        },
       },
-      content: 'There is some problem.'
+      content: 'There is some problem.',
     }]);
   });
 
@@ -325,19 +325,19 @@ describe('Creating element IDs', () => {
       meta: {
         id: {
           element: 'string',
-          content: 'exampleID'
+          content: 'exampleID',
         },
         links: [
           {
             element: 'link',
             attributes: {
               relation: 'profile',
-              href: 'https://example.com/annotation'
-            }
-          }
-        ]
+              href: 'https://example.com/annotation',
+            },
+          },
+        ],
       },
-      content: 'There is some problem.'
+      content: 'There is some problem.',
     }];
 
     const output = abagnale.forge(input);
@@ -347,26 +347,26 @@ describe('Creating element IDs', () => {
       meta: {
         id: {
           element: 'string',
-          content: 'exampleID'
+          content: 'exampleID',
         },
         links: [
           {
             element: 'link',
             attributes: {
               relation: 'profile',
-              href: 'https://example.com/annotation'
-            }
+              href: 'https://example.com/annotation',
+            },
           },
           {
             element: 'link',
             attributes: {
               href: 'exampleid',
-              relation: 'uri-fragment'
-            }
-          }
-        ]
+              relation: 'uri-fragment',
+            },
+          },
+        ],
       },
-      content: 'There is some problem.'
+      content: 'There is some problem.',
     }]);
   });
 
@@ -376,7 +376,7 @@ describe('Creating element IDs', () => {
       meta: {
         id: {
           element: 'string',
-          content: 'exampleID'
+          content: 'exampleID',
         },
         links: {
           element: 'array',
@@ -385,13 +385,13 @@ describe('Creating element IDs', () => {
               element: 'link',
               attributes: {
                 relation: 'profile',
-                href: 'https://example.com/annotation'
-              }
-            }
-          ]
-        }
+                href: 'https://example.com/annotation',
+              },
+            },
+          ],
+        },
       },
-      content: 'There is some problem.'
+      content: 'There is some problem.',
     }];
 
     const output = abagnale.forge(input);
@@ -401,7 +401,7 @@ describe('Creating element IDs', () => {
       meta: {
         id: {
           element: 'string',
-          content: 'exampleID'
+          content: 'exampleID',
         },
         links: {
           element: 'array',
@@ -410,20 +410,20 @@ describe('Creating element IDs', () => {
               element: 'link',
               attributes: {
                 relation: 'profile',
-                href: 'https://example.com/annotation'
-              }
+                href: 'https://example.com/annotation',
+              },
             },
             {
               element: 'link',
               attributes: {
                 href: 'exampleid',
-                relation: 'uri-fragment'
-              }
-            }
-          ]
-        }
+                relation: 'uri-fragment',
+              },
+            },
+          ],
+        },
       },
-      content: 'There is some problem.'
+      content: 'There is some problem.',
     }]);
   });
 });

--- a/test/abagnale.js
+++ b/test/abagnale.js
@@ -104,6 +104,53 @@ describe('Creating element IDs', () => {
     }]);
   });
 
+  it('should leave existing refracted ID unmodified', () => {
+    const input = [{
+      element: 'annotation',
+      meta: {
+        id: {
+          element: 'string',
+          attributes: {
+            attr: {
+              element: 'string',
+              content: 'Example'
+            }
+          },
+          content: 'exampleID'
+        }
+      },
+      content: 'There is some problem.'
+    }];
+
+    const output = abagnale.forge(input);
+
+    assert.deepEqual(output, [{
+      element: 'annotation',
+      meta: {
+        id: {
+          element: 'string',
+          attributes: {
+            attr: {
+              element: 'string',
+              content: 'Example'
+            }
+          },
+          content: 'exampleID'
+        },
+        links: [
+          {
+            element: 'link',
+            content: {
+              href: 'exampleid',
+              relation: 'uri-fragment'
+            }
+          }
+        ]
+      },
+      content: 'There is some problem.'
+    }]);
+  });
+
   it('should generate ID from element name', () => {
     const input = [{
       element: 'annotation',

--- a/test/abagnale.js
+++ b/test/abagnale.js
@@ -265,6 +265,149 @@ describe('Creating element IDs', () => {
       content: 'There is some problem.'
     }]);
   });
+
+  it('should add link elements for ID', () => {
+    const input = [{
+      element: 'annotation',
+      meta: {
+        id: {
+          element: 'string',
+          content: 'exampleID'
+        }
+      },
+      content: 'There is some problem.'
+    }];
+
+    const output = abagnale.forge(input);
+
+    assert.deepEqual(output, [{
+      element: 'annotation',
+      meta: {
+        id: {
+          element: 'string',
+          content: 'exampleID'
+        },
+        links: [
+          {
+            element: 'link',
+            content: {
+              href: 'exampleid',
+              relation: 'uri-fragment'
+            }
+          }
+        ]
+      },
+      content: 'There is some problem.'
+    }]);
+  });
+
+  it('should append link element to existing link elements for ID', () => {
+    const input = [{
+      element: 'annotation',
+      meta: {
+        id: {
+          element: 'string',
+          content: 'exampleID'
+        },
+        links: [
+          {
+            element: 'link',
+            attributes: {
+              relation: 'profile',
+              href: 'https://example.com/annotation'
+            }
+          }
+        ]
+      },
+      content: 'There is some problem.'
+    }];
+
+    const output = abagnale.forge(input);
+
+    assert.deepEqual(output, [{
+      element: 'annotation',
+      meta: {
+        id: {
+          element: 'string',
+          content: 'exampleID'
+        },
+        links: [
+          {
+            element: 'link',
+            attributes: {
+              relation: 'profile',
+              href: 'https://example.com/annotation'
+            }
+          },
+          {
+            element: 'link',
+            content: {
+              href: 'exampleid',
+              relation: 'uri-fragment'
+            }
+          }
+        ]
+      },
+      content: 'There is some problem.'
+    }]);
+  });
+
+  it('should append link element to existing link elements array element for ID', () => {
+    const input = [{
+      element: 'annotation',
+      meta: {
+        id: {
+          element: 'string',
+          content: 'exampleID'
+        },
+        links: {
+          element: 'array',
+          content: [
+            {
+              element: 'link',
+              attributes: {
+                relation: 'profile',
+                href: 'https://example.com/annotation'
+              }
+            }
+          ]
+        }
+      },
+      content: 'There is some problem.'
+    }];
+
+    const output = abagnale.forge(input);
+
+    assert.deepEqual(output, [{
+      element: 'annotation',
+      meta: {
+        id: {
+          element: 'string',
+          content: 'exampleID'
+        },
+        links: {
+          element: 'array',
+          content: [
+            {
+              element: 'link',
+              attributes: {
+                relation: 'profile',
+                href: 'https://example.com/annotation'
+              }
+            },
+            {
+              element: 'link',
+              content: {
+                href: 'exampleid',
+                relation: 'uri-fragment'
+              }
+            }
+          ]
+        }
+      },
+      content: 'There is some problem.'
+    }]);
+  });
 });
 
 describe('Test fixtures match expected output', () => {

--- a/test/abagnale.js
+++ b/test/abagnale.js
@@ -86,7 +86,10 @@ describe('Creating element IDs', () => {
     assert.deepEqual(output, [{
       element: 'annotation',
       meta: {
-        id: 'exampleID',
+        id: {
+          element: 'string',
+          content: 'exampleID'
+        },
         links: [
           {
             element: 'link',
@@ -112,7 +115,10 @@ describe('Creating element IDs', () => {
     assert.deepEqual(output, [{
       element: 'annotation',
       meta: {
-        id: 'annotation',
+        id: {
+          element: 'string',
+          content: 'annotation'
+        },
         links: [
           {
             element: 'link',
@@ -143,7 +149,10 @@ describe('Creating element IDs', () => {
     assert.deepEqual(output, [{
       element: 'annotation',
       meta: {
-        id: 'warning',
+        id: {
+          element: 'string',
+          content: 'warning'
+        },
         classes: [
           'warning'
         ],
@@ -183,7 +192,10 @@ describe('Creating element IDs', () => {
     assert.deepEqual(output, [{
       element: 'annotation',
       meta: {
-        id: 'warning',
+        id: {
+          element: 'string',
+          content: 'warning'
+        },
         classes: {
           element: 'array',
           content: [

--- a/test/abagnale.js
+++ b/test/abagnale.js
@@ -90,15 +90,18 @@ describe('Creating element IDs', () => {
           element: 'string',
           content: 'exampleID'
         },
-        links: [
-          {
-            element: 'link',
-            content: {
-              href: 'exampleid',
-              relation: 'uri-fragment'
+        links: {
+          element: 'array',
+          content: [
+            {
+              element: 'link',
+              content: {
+                href: 'exampleid',
+                relation: 'uri-fragment'
+              }
             }
-          }
-        ]
+          ]
+        }
       },
       content: 'There is some problem.'
     }]);
@@ -137,15 +140,18 @@ describe('Creating element IDs', () => {
           },
           content: 'exampleID'
         },
-        links: [
-          {
-            element: 'link',
-            content: {
-              href: 'exampleid',
-              relation: 'uri-fragment'
+        links: {
+          element: 'array',
+          content: [
+            {
+              element: 'link',
+              content: {
+                href: 'exampleid',
+                relation: 'uri-fragment'
+              }
             }
-          }
-        ]
+          ]
+        }
       },
       content: 'There is some problem.'
     }]);
@@ -166,15 +172,18 @@ describe('Creating element IDs', () => {
           element: 'string',
           content: 'annotation'
         },
-        links: [
-          {
-            element: 'link',
-            content: {
-              href: 'annotation',
-              relation: 'uri-fragment'
+        links: {
+          element: 'array',
+          content: [
+            {
+              element: 'link',
+              content: {
+                href: 'annotation',
+                relation: 'uri-fragment'
+              }
             }
-          }
-        ]
+          ]
+        }
       },
       content: 'There is some problem.'
     }]);
@@ -203,15 +212,18 @@ describe('Creating element IDs', () => {
         classes: [
           'warning'
         ],
-        links: [
-          {
-            element: 'link',
-            content: {
-              href: 'warning',
-              relation: 'uri-fragment'
+        links: {
+          element: 'array',
+          content: [
+            {
+              element: 'link',
+              content: {
+                href: 'warning',
+                relation: 'uri-fragment'
+              }
             }
-          }
-        ]
+          ]
+        }
       },
       content: 'There is some problem.'
     }]);
@@ -252,15 +264,18 @@ describe('Creating element IDs', () => {
             }
           ]
         },
-        links: [
-          {
-            element: 'link',
-            content: {
-              href: 'warning',
-              relation: 'uri-fragment'
+        links: {
+          element: 'array',
+          content: [
+            {
+              element: 'link',
+              content: {
+                href: 'warning',
+                relation: 'uri-fragment'
+              }
             }
-          }
-        ]
+          ]
+        }
       },
       content: 'There is some problem.'
     }]);
@@ -287,15 +302,18 @@ describe('Creating element IDs', () => {
           element: 'string',
           content: 'exampleID'
         },
-        links: [
-          {
-            element: 'link',
-            content: {
-              href: 'exampleid',
-              relation: 'uri-fragment'
+        links: {
+          element: 'array',
+          content: [
+            {
+              element: 'link',
+              content: {
+                href: 'exampleid',
+                relation: 'uri-fragment'
+              }
             }
-          }
-        ]
+          ]
+        }
       },
       content: 'There is some problem.'
     }]);

--- a/test/abagnale.js
+++ b/test/abagnale.js
@@ -95,7 +95,7 @@ describe('Creating element IDs', () => {
           content: [
             {
               element: 'link',
-              content: {
+              attributes: {
                 href: 'exampleid',
                 relation: 'uri-fragment'
               }
@@ -145,7 +145,7 @@ describe('Creating element IDs', () => {
           content: [
             {
               element: 'link',
-              content: {
+              attributes: {
                 href: 'exampleid',
                 relation: 'uri-fragment'
               }
@@ -177,7 +177,7 @@ describe('Creating element IDs', () => {
           content: [
             {
               element: 'link',
-              content: {
+              attributes: {
                 href: 'annotation',
                 relation: 'uri-fragment'
               }
@@ -217,7 +217,7 @@ describe('Creating element IDs', () => {
           content: [
             {
               element: 'link',
-              content: {
+              attributes: {
                 href: 'warning',
                 relation: 'uri-fragment'
               }
@@ -269,7 +269,7 @@ describe('Creating element IDs', () => {
           content: [
             {
               element: 'link',
-              content: {
+              attributes: {
                 href: 'warning',
                 relation: 'uri-fragment'
               }
@@ -307,7 +307,7 @@ describe('Creating element IDs', () => {
           content: [
             {
               element: 'link',
-              content: {
+              attributes: {
                 href: 'exampleid',
                 relation: 'uri-fragment'
               }
@@ -359,7 +359,7 @@ describe('Creating element IDs', () => {
           },
           {
             element: 'link',
-            content: {
+            attributes: {
               href: 'exampleid',
               relation: 'uri-fragment'
             }
@@ -415,7 +415,7 @@ describe('Creating element IDs', () => {
             },
             {
               element: 'link',
-              content: {
+              attributes: {
                 href: 'exampleid',
                 relation: 'uri-fragment'
               }

--- a/test/abagnale.js
+++ b/test/abagnale.js
@@ -160,6 +160,52 @@ describe('Creating element IDs', () => {
       content: 'There is some problem.'
     }]);
   });
+
+  it('should generate ID from first refracted class', () => {
+    const input = [{
+      element: 'annotation',
+      meta: {
+        classes: {
+          element: 'array',
+          content: [
+            {
+              element: 'string',
+              content: 'warning'
+            }
+          ]
+        }
+      },
+      content: 'There is some problem.'
+    }];
+
+    const output = abagnale.forge(input);
+
+    assert.deepEqual(output, [{
+      element: 'annotation',
+      meta: {
+        id: 'warning',
+        classes: {
+          element: 'array',
+          content: [
+            {
+              element: 'string',
+              content: 'warning'
+            }
+          ]
+        },
+        links: [
+          {
+            element: 'link',
+            content: {
+              href: 'warning',
+              relation: 'uri-fragment'
+            }
+          }
+        ]
+      },
+      content: 'There is some problem.'
+    }]);
+  });
 });
 
 describe('Test fixtures match expected output', () => {

--- a/test/output/api.json
+++ b/test/output/api.json
@@ -6,7 +6,10 @@
         "api"
       ],
       "title": "My API",
-      "id": "api",
+      "id": {
+        "element": "string",
+        "content": "api"
+      },
       "links": [
         {
           "element": "link",
@@ -47,7 +50,10 @@
             "resourceGroup"
           ],
           "title": "",
-          "id": "api.resourcegroup",
+          "id": {
+            "element": "string",
+            "content": "api.resourcegroup"
+          },
           "links": [
             {
               "element": "link",
@@ -63,7 +69,10 @@
             "element": "resource",
             "meta": {
               "title": "Frob",
-              "id": "api.resourcegroup.frob",
+              "id": {
+                "element": "string",
+                "content": "api.resourcegroup.frob"
+              },
               "links": [
                 {
                   "element": "link",
@@ -82,7 +91,10 @@
                 "element": "transition",
                 "meta": {
                   "title": "Get a frob",
-                  "id": "api.resourcegroup.frob.get-a-frob",
+                  "id": {
+                    "element": "string",
+                    "content": "api.resourcegroup.frob.get-a-frob"
+                  },
                   "links": [
                     {
                       "element": "link",
@@ -104,7 +116,10 @@
                         },
                         "content": [],
                         "meta": {
-                          "id": "api.resourcegroup.frob.get-a-frob.httptransaction.httprequest",
+                          "id": {
+                            "element": "string",
+                            "content": "api.resourcegroup.frob.get-a-frob.httptransaction.httprequest"
+                          },
                           "links": [
                             {
                               "element": "link",
@@ -135,7 +150,10 @@
                                         "element": "string",
                                         "content": "id",
                                         "meta": {
-                                          "id": "api.resourcegroup.frob.get-a-frob.httptransaction.httpresponse.datastructure.0.id-key",
+                                          "id": {
+                                            "element": "string",
+                                            "content": "api.resourcegroup.frob.get-a-frob.httptransaction.httpresponse.datastructure.0.id-key"
+                                          },
                                           "links": [
                                             {
                                               "element": "link",
@@ -151,7 +169,10 @@
                                         "element": "string",
                                         "content": "123",
                                         "meta": {
-                                          "id": "api.resourcegroup.frob.get-a-frob.httptransaction.httpresponse.datastructure.0.id",
+                                          "id": {
+                                            "element": "string",
+                                            "content": "api.resourcegroup.frob.get-a-frob.httptransaction.httpresponse.datastructure.0.id"
+                                          },
                                           "links": [
                                             {
                                               "element": "link",
@@ -165,7 +186,10 @@
                                       }
                                     },
                                     "meta": {
-                                      "id": "api.resourcegroup.frob.get-a-frob.httptransaction.httpresponse.datastructure.0.id-member",
+                                      "id": {
+                                        "element": "string",
+                                        "content": "api.resourcegroup.frob.get-a-frob.httptransaction.httpresponse.datastructure.0.id-member"
+                                      },
                                       "links": [
                                         {
                                           "element": "link",
@@ -179,7 +203,10 @@
                                   }
                                 ],
                                 "meta": {
-                                  "id": "api.resourcegroup.frob.get-a-frob.httptransaction.httpresponse.datastructure.0",
+                                  "id": {
+                                    "element": "string",
+                                    "content": "api.resourcegroup.frob.get-a-frob.httptransaction.httpresponse.datastructure.0"
+                                  },
                                   "links": [
                                     {
                                       "element": "link",
@@ -193,7 +220,10 @@
                               }
                             ],
                             "meta": {
-                              "id": "api.resourcegroup.frob.get-a-frob.httptransaction.httpresponse.datastructure",
+                              "id": {
+                                "element": "string",
+                                "content": "api.resourcegroup.frob.get-a-frob.httptransaction.httpresponse.datastructure"
+                              },
                               "links": [
                                 {
                                   "element": "link",
@@ -211,7 +241,10 @@
                               "classes": [
                                 "messageBodySchema"
                               ],
-                              "id": "api.resourcegroup.frob.get-a-frob.httptransaction.httpresponse.messagebodyschema",
+                              "id": {
+                                "element": "string",
+                                "content": "api.resourcegroup.frob.get-a-frob.httptransaction.httpresponse.messagebodyschema"
+                              },
                               "links": [
                                 {
                                   "element": "link",
@@ -226,7 +259,10 @@
                           }
                         ],
                         "meta": {
-                          "id": "api.resourcegroup.frob.get-a-frob.httptransaction.httpresponse",
+                          "id": {
+                            "element": "string",
+                            "content": "api.resourcegroup.frob.get-a-frob.httptransaction.httpresponse"
+                          },
                           "links": [
                             {
                               "element": "link",
@@ -240,7 +276,10 @@
                       }
                     ],
                     "meta": {
-                      "id": "api.resourcegroup.frob.get-a-frob.httptransaction",
+                      "id": {
+                        "element": "string",
+                        "content": "api.resourcegroup.frob.get-a-frob.httptransaction"
+                      },
                       "links": [
                         {
                           "element": "link",

--- a/test/output/api.json
+++ b/test/output/api.json
@@ -10,15 +10,18 @@
         "element": "string",
         "content": "api"
       },
-      "links": [
-        {
-          "element": "link",
-          "content": {
-            "relation": "uri-fragment",
-            "href": "api"
+      "links": {
+        "element": "array",
+        "content": [
+          {
+            "element": "link",
+            "content": {
+              "relation": "uri-fragment",
+              "href": "api"
+            }
           }
-        }
-      ]
+        ]
+      }
     },
     "attributes": {
       "meta": [
@@ -54,15 +57,18 @@
             "element": "string",
             "content": "api.resourcegroup"
           },
-          "links": [
-            {
-              "element": "link",
-              "content": {
-                "relation": "uri-fragment",
-                "href": "api/resourcegroup"
+          "links": {
+            "element": "array",
+            "content": [
+              {
+                "element": "link",
+                "content": {
+                  "relation": "uri-fragment",
+                  "href": "api/resourcegroup"
+                }
               }
-            }
-          ]
+            ]
+          }
         },
         "content": [
           {
@@ -73,15 +79,18 @@
                 "element": "string",
                 "content": "api.resourcegroup.frob"
               },
-              "links": [
-                {
-                  "element": "link",
-                  "content": {
-                    "relation": "uri-fragment",
-                    "href": "api/resourcegroup/frob"
+              "links": {
+                "element": "array",
+                "content": [
+                  {
+                    "element": "link",
+                    "content": {
+                      "relation": "uri-fragment",
+                      "href": "api/resourcegroup/frob"
+                    }
                   }
-                }
-              ]
+                ]
+              }
             },
             "attributes": {
               "href": "/frobs"
@@ -95,15 +104,18 @@
                     "element": "string",
                     "content": "api.resourcegroup.frob.get-a-frob"
                   },
-                  "links": [
-                    {
-                      "element": "link",
-                      "content": {
-                        "relation": "uri-fragment",
-                        "href": "api/resourcegroup/frob/get-a-frob"
+                  "links": {
+                    "element": "array",
+                    "content": [
+                      {
+                        "element": "link",
+                        "content": {
+                          "relation": "uri-fragment",
+                          "href": "api/resourcegroup/frob/get-a-frob"
+                        }
                       }
-                    }
-                  ]
+                    ]
+                  }
                 },
                 "content": [
                   {
@@ -120,15 +132,18 @@
                             "element": "string",
                             "content": "api.resourcegroup.frob.get-a-frob.httptransaction.httprequest"
                           },
-                          "links": [
-                            {
-                              "element": "link",
-                              "content": {
-                                "relation": "uri-fragment",
-                                "href": "api/resourcegroup/frob/get-a-frob/httptransaction/httprequest"
+                          "links": {
+                            "element": "array",
+                            "content": [
+                              {
+                                "element": "link",
+                                "content": {
+                                  "relation": "uri-fragment",
+                                  "href": "api/resourcegroup/frob/get-a-frob/httptransaction/httprequest"
+                                }
                               }
-                            }
-                          ]
+                            ]
+                          }
                         }
                       },
                       {
@@ -154,15 +169,18 @@
                                             "element": "string",
                                             "content": "api.resourcegroup.frob.get-a-frob.httptransaction.httpresponse.datastructure.0.id-key"
                                           },
-                                          "links": [
-                                            {
-                                              "element": "link",
-                                              "content": {
-                                                "relation": "uri-fragment",
-                                                "href": "api/resourcegroup/frob/get-a-frob/httptransaction/httpresponse/datastructure/0/id-key"
+                                          "links": {
+                                            "element": "array",
+                                            "content": [
+                                              {
+                                                "element": "link",
+                                                "content": {
+                                                  "relation": "uri-fragment",
+                                                  "href": "api/resourcegroup/frob/get-a-frob/httptransaction/httpresponse/datastructure/0/id-key"
+                                                }
                                               }
-                                            }
-                                          ]
+                                            ]
+                                          }
                                         }
                                       },
                                       "value": {
@@ -173,15 +191,18 @@
                                             "element": "string",
                                             "content": "api.resourcegroup.frob.get-a-frob.httptransaction.httpresponse.datastructure.0.id"
                                           },
-                                          "links": [
-                                            {
-                                              "element": "link",
-                                              "content": {
-                                                "relation": "uri-fragment",
-                                                "href": "api/resourcegroup/frob/get-a-frob/httptransaction/httpresponse/datastructure/0/id"
+                                          "links": {
+                                            "element": "array",
+                                            "content": [
+                                              {
+                                                "element": "link",
+                                                "content": {
+                                                  "relation": "uri-fragment",
+                                                  "href": "api/resourcegroup/frob/get-a-frob/httptransaction/httpresponse/datastructure/0/id"
+                                                }
                                               }
-                                            }
-                                          ]
+                                            ]
+                                          }
                                         }
                                       }
                                     },
@@ -190,15 +211,18 @@
                                         "element": "string",
                                         "content": "api.resourcegroup.frob.get-a-frob.httptransaction.httpresponse.datastructure.0.id-member"
                                       },
-                                      "links": [
-                                        {
-                                          "element": "link",
-                                          "content": {
-                                            "relation": "uri-fragment",
-                                            "href": "api/resourcegroup/frob/get-a-frob/httptransaction/httpresponse/datastructure/0/id-member"
+                                      "links": {
+                                        "element": "array",
+                                        "content": [
+                                          {
+                                            "element": "link",
+                                            "content": {
+                                              "relation": "uri-fragment",
+                                              "href": "api/resourcegroup/frob/get-a-frob/httptransaction/httpresponse/datastructure/0/id-member"
+                                            }
                                           }
-                                        }
-                                      ]
+                                        ]
+                                      }
                                     }
                                   }
                                 ],
@@ -207,15 +231,18 @@
                                     "element": "string",
                                     "content": "api.resourcegroup.frob.get-a-frob.httptransaction.httpresponse.datastructure.0"
                                   },
-                                  "links": [
-                                    {
-                                      "element": "link",
-                                      "content": {
-                                        "relation": "uri-fragment",
-                                        "href": "api/resourcegroup/frob/get-a-frob/httptransaction/httpresponse/datastructure/0"
+                                  "links": {
+                                    "element": "array",
+                                    "content": [
+                                      {
+                                        "element": "link",
+                                        "content": {
+                                          "relation": "uri-fragment",
+                                          "href": "api/resourcegroup/frob/get-a-frob/httptransaction/httpresponse/datastructure/0"
+                                        }
                                       }
-                                    }
-                                  ]
+                                    ]
+                                  }
                                 }
                               }
                             ],
@@ -224,15 +251,18 @@
                                 "element": "string",
                                 "content": "api.resourcegroup.frob.get-a-frob.httptransaction.httpresponse.datastructure"
                               },
-                              "links": [
-                                {
-                                  "element": "link",
-                                  "content": {
-                                    "relation": "uri-fragment",
-                                    "href": "api/resourcegroup/frob/get-a-frob/httptransaction/httpresponse/datastructure"
+                              "links": {
+                                "element": "array",
+                                "content": [
+                                  {
+                                    "element": "link",
+                                    "content": {
+                                      "relation": "uri-fragment",
+                                      "href": "api/resourcegroup/frob/get-a-frob/httptransaction/httpresponse/datastructure"
+                                    }
                                   }
-                                }
-                              ]
+                                ]
+                              }
                             }
                           },
                           {
@@ -245,15 +275,18 @@
                                 "element": "string",
                                 "content": "api.resourcegroup.frob.get-a-frob.httptransaction.httpresponse.messagebodyschema"
                               },
-                              "links": [
-                                {
-                                  "element": "link",
-                                  "content": {
-                                    "relation": "uri-fragment",
-                                    "href": "api/resourcegroup/frob/get-a-frob/httptransaction/httpresponse/messagebodyschema"
+                              "links": {
+                                "element": "array",
+                                "content": [
+                                  {
+                                    "element": "link",
+                                    "content": {
+                                      "relation": "uri-fragment",
+                                      "href": "api/resourcegroup/frob/get-a-frob/httptransaction/httpresponse/messagebodyschema"
+                                    }
                                   }
-                                }
-                              ]
+                                ]
+                              }
                             },
                             "content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"id\": {\n      \"type\": \"string\"\n    }\n  }\n}"
                           }
@@ -263,15 +296,18 @@
                             "element": "string",
                             "content": "api.resourcegroup.frob.get-a-frob.httptransaction.httpresponse"
                           },
-                          "links": [
-                            {
-                              "element": "link",
-                              "content": {
-                                "relation": "uri-fragment",
-                                "href": "api/resourcegroup/frob/get-a-frob/httptransaction/httpresponse"
+                          "links": {
+                            "element": "array",
+                            "content": [
+                              {
+                                "element": "link",
+                                "content": {
+                                  "relation": "uri-fragment",
+                                  "href": "api/resourcegroup/frob/get-a-frob/httptransaction/httpresponse"
+                                }
                               }
-                            }
-                          ]
+                            ]
+                          }
                         }
                       }
                     ],
@@ -280,15 +316,18 @@
                         "element": "string",
                         "content": "api.resourcegroup.frob.get-a-frob.httptransaction"
                       },
-                      "links": [
-                        {
-                          "element": "link",
-                          "content": {
-                            "relation": "uri-fragment",
-                            "href": "api/resourcegroup/frob/get-a-frob/httptransaction"
+                      "links": {
+                        "element": "array",
+                        "content": [
+                          {
+                            "element": "link",
+                            "content": {
+                              "relation": "uri-fragment",
+                              "href": "api/resourcegroup/frob/get-a-frob/httptransaction"
+                            }
                           }
-                        }
-                      ]
+                        ]
+                      }
                     }
                   }
                 ]

--- a/test/output/api.json
+++ b/test/output/api.json
@@ -15,7 +15,7 @@
         "content": [
           {
             "element": "link",
-            "content": {
+            "attributes": {
               "relation": "uri-fragment",
               "href": "api"
             }
@@ -62,7 +62,7 @@
             "content": [
               {
                 "element": "link",
-                "content": {
+                "attributes": {
                   "relation": "uri-fragment",
                   "href": "api/resourcegroup"
                 }
@@ -84,7 +84,7 @@
                 "content": [
                   {
                     "element": "link",
-                    "content": {
+                    "attributes": {
                       "relation": "uri-fragment",
                       "href": "api/resourcegroup/frob"
                     }
@@ -109,7 +109,7 @@
                     "content": [
                       {
                         "element": "link",
-                        "content": {
+                        "attributes": {
                           "relation": "uri-fragment",
                           "href": "api/resourcegroup/frob/get-a-frob"
                         }
@@ -137,7 +137,7 @@
                             "content": [
                               {
                                 "element": "link",
-                                "content": {
+                                "attributes": {
                                   "relation": "uri-fragment",
                                   "href": "api/resourcegroup/frob/get-a-frob/httptransaction/httprequest"
                                 }
@@ -174,7 +174,7 @@
                                             "content": [
                                               {
                                                 "element": "link",
-                                                "content": {
+                                                "attributes": {
                                                   "relation": "uri-fragment",
                                                   "href": "api/resourcegroup/frob/get-a-frob/httptransaction/httpresponse/datastructure/0/id-key"
                                                 }
@@ -196,7 +196,7 @@
                                             "content": [
                                               {
                                                 "element": "link",
-                                                "content": {
+                                                "attributes": {
                                                   "relation": "uri-fragment",
                                                   "href": "api/resourcegroup/frob/get-a-frob/httptransaction/httpresponse/datastructure/0/id"
                                                 }
@@ -216,7 +216,7 @@
                                         "content": [
                                           {
                                             "element": "link",
-                                            "content": {
+                                            "attributes": {
                                               "relation": "uri-fragment",
                                               "href": "api/resourcegroup/frob/get-a-frob/httptransaction/httpresponse/datastructure/0/id-member"
                                             }
@@ -236,7 +236,7 @@
                                     "content": [
                                       {
                                         "element": "link",
-                                        "content": {
+                                        "attributes": {
                                           "relation": "uri-fragment",
                                           "href": "api/resourcegroup/frob/get-a-frob/httptransaction/httpresponse/datastructure/0"
                                         }
@@ -256,7 +256,7 @@
                                 "content": [
                                   {
                                     "element": "link",
-                                    "content": {
+                                    "attributes": {
                                       "relation": "uri-fragment",
                                       "href": "api/resourcegroup/frob/get-a-frob/httptransaction/httpresponse/datastructure"
                                     }
@@ -280,7 +280,7 @@
                                 "content": [
                                   {
                                     "element": "link",
-                                    "content": {
+                                    "attributes": {
                                       "relation": "uri-fragment",
                                       "href": "api/resourcegroup/frob/get-a-frob/httptransaction/httpresponse/messagebodyschema"
                                     }
@@ -301,7 +301,7 @@
                             "content": [
                               {
                                 "element": "link",
-                                "content": {
+                                "attributes": {
                                   "relation": "uri-fragment",
                                   "href": "api/resourcegroup/frob/get-a-frob/httptransaction/httpresponse"
                                 }
@@ -321,7 +321,7 @@
                         "content": [
                           {
                             "element": "link",
-                            "content": {
+                            "attributes": {
                               "relation": "uri-fragment",
                               "href": "api/resourcegroup/frob/get-a-frob/httptransaction"
                             }

--- a/test/output/arrays.json
+++ b/test/output/arrays.json
@@ -14,7 +14,7 @@
             "content": [
               {
                 "element": "link",
-                "content": {
+                "attributes": {
                   "relation": "uri-fragment",
                   "href": "array/0"
                 }
@@ -38,7 +38,7 @@
                 "content": [
                   {
                     "element": "link",
-                    "content": {
+                    "attributes": {
                       "relation": "uri-fragment",
                       "href": "array/1/0"
                     }
@@ -58,7 +58,7 @@
             "content": [
               {
                 "element": "link",
-                "content": {
+                "attributes": {
                   "relation": "uri-fragment",
                   "href": "array/1"
                 }
@@ -78,7 +78,7 @@
         "content": [
           {
             "element": "link",
-            "content": {
+            "attributes": {
               "relation": "uri-fragment",
               "href": "array"
             }

--- a/test/output/arrays.json
+++ b/test/output/arrays.json
@@ -5,7 +5,10 @@
       {
         "element": "string",
         "meta": {
-          "id": "array.0",
+          "id": {
+            "element": "string",
+            "content": "array.0"
+          },
           "links": [
             {
               "element": "link",
@@ -23,7 +26,10 @@
           {
             "element": "number",
             "meta": {
-              "id": "array.1.0",
+              "id": {
+                "element": "string",
+                "content": "array.1.0"
+              },
               "links": [
                 {
                   "element": "link",
@@ -37,7 +43,10 @@
           }
         ],
         "meta": {
-          "id": "array.1",
+          "id": {
+            "element": "string",
+            "content": "array.1"
+          },
           "links": [
             {
               "element": "link",
@@ -51,7 +60,10 @@
       }
     ],
     "meta": {
-      "id": "array",
+      "id": {
+        "element": "string",
+        "content": "array"
+      },
       "links": [
         {
           "element": "link",

--- a/test/output/arrays.json
+++ b/test/output/arrays.json
@@ -9,15 +9,18 @@
             "element": "string",
             "content": "array.0"
           },
-          "links": [
-            {
-              "element": "link",
-              "content": {
-                "relation": "uri-fragment",
-                "href": "array/0"
+          "links": {
+            "element": "array",
+            "content": [
+              {
+                "element": "link",
+                "content": {
+                  "relation": "uri-fragment",
+                  "href": "array/0"
+                }
               }
-            }
-          ]
+            ]
+          }
         }
       },
       {
@@ -30,15 +33,18 @@
                 "element": "string",
                 "content": "array.1.0"
               },
-              "links": [
-                {
-                  "element": "link",
-                  "content": {
-                    "relation": "uri-fragment",
-                    "href": "array/1/0"
+              "links": {
+                "element": "array",
+                "content": [
+                  {
+                    "element": "link",
+                    "content": {
+                      "relation": "uri-fragment",
+                      "href": "array/1/0"
+                    }
                   }
-                }
-              ]
+                ]
+              }
             }
           }
         ],
@@ -47,15 +53,18 @@
             "element": "string",
             "content": "array.1"
           },
-          "links": [
-            {
-              "element": "link",
-              "content": {
-                "relation": "uri-fragment",
-                "href": "array/1"
+          "links": {
+            "element": "array",
+            "content": [
+              {
+                "element": "link",
+                "content": {
+                  "relation": "uri-fragment",
+                  "href": "array/1"
+                }
               }
-            }
-          ]
+            ]
+          }
         }
       }
     ],
@@ -64,15 +73,18 @@
         "element": "string",
         "content": "array"
       },
-      "links": [
-        {
-          "element": "link",
-          "content": {
-            "relation": "uri-fragment",
-            "href": "array"
+      "links": {
+        "element": "array",
+        "content": [
+          {
+            "element": "link",
+            "content": {
+              "relation": "uri-fragment",
+              "href": "array"
+            }
           }
-        }
-      ]
+        ]
+      }
     }
   }
 ]

--- a/test/output/element-id-refacted.json
+++ b/test/output/element-id-refacted.json
@@ -6,15 +6,18 @@
         "element": "string",
         "content": "Hello World"
       },
-      "links": [
-        {
-          "element": "link",
-          "content": {
-            "relation": "uri-fragment",
-            "href": "hello-world"
+      "links": {
+        "element": "array",
+        "content": [
+          {
+            "element": "link",
+            "content": {
+              "relation": "uri-fragment",
+              "href": "hello-world"
+            }
           }
-        }
-      ]
+        ]
+      }
     }
   }
 ]

--- a/test/output/element-id-refacted.json
+++ b/test/output/element-id-refacted.json
@@ -11,7 +11,7 @@
         "content": [
           {
             "element": "link",
-            "content": {
+            "attributes": {
               "relation": "uri-fragment",
               "href": "hello-world"
             }

--- a/test/output/element-id-refacted.json
+++ b/test/output/element-id-refacted.json
@@ -2,13 +2,16 @@
   {
     "element": "string",
     "meta": {
-      "id": "Hello World",
+      "id": {
+        "element": "string",
+        "content": "Hello World"
+      },
       "links": [
         {
           "element": "link",
           "content": {
-            "href": "hello-world",
-            "relation": "uri-fragment"
+            "relation": "uri-fragment",
+            "href": "hello-world"
           }
         }
       ]

--- a/test/output/element-id.json
+++ b/test/output/element-id.json
@@ -6,15 +6,18 @@
         "element": "string",
         "content": "Hello World"
       },
-      "links": [
-        {
-          "element": "link",
-          "content": {
-            "relation": "uri-fragment",
-            "href": "hello-world"
+      "links": {
+        "element": "array",
+        "content": [
+          {
+            "element": "link",
+            "content": {
+              "relation": "uri-fragment",
+              "href": "hello-world"
+            }
           }
-        }
-      ]
+        ]
+      }
     }
   }
 ]

--- a/test/output/element-id.json
+++ b/test/output/element-id.json
@@ -11,7 +11,7 @@
         "content": [
           {
             "element": "link",
-            "content": {
+            "attributes": {
               "relation": "uri-fragment",
               "href": "hello-world"
             }

--- a/test/output/element-id.json
+++ b/test/output/element-id.json
@@ -2,13 +2,16 @@
   {
     "element": "string",
     "meta": {
-      "id": "Hello World",
+      "id": {
+        "element": "string",
+        "content": "Hello World"
+      },
       "links": [
         {
           "element": "link",
           "content": {
-            "href": "hello-world",
-            "relation": "uri-fragment"
+            "relation": "uri-fragment",
+            "href": "hello-world"
           }
         }
       ]

--- a/test/output/objects.json
+++ b/test/output/objects.json
@@ -13,15 +13,18 @@
                 "element": "string",
                 "content": "object.name-key"
               },
-              "links": [
-                {
-                  "element": "link",
-                  "content": {
-                    "relation": "uri-fragment",
-                    "href": "object/name-key"
+              "links": {
+                "element": "array",
+                "content": [
+                  {
+                    "element": "link",
+                    "content": {
+                      "relation": "uri-fragment",
+                      "href": "object/name-key"
+                    }
                   }
-                }
-              ]
+                ]
+              }
             }
           },
           "value": {
@@ -31,15 +34,18 @@
                 "element": "string",
                 "content": "object.name"
               },
-              "links": [
-                {
-                  "element": "link",
-                  "content": {
-                    "relation": "uri-fragment",
-                    "href": "object/name"
+              "links": {
+                "element": "array",
+                "content": [
+                  {
+                    "element": "link",
+                    "content": {
+                      "relation": "uri-fragment",
+                      "href": "object/name"
+                    }
                   }
-                }
-              ]
+                ]
+              }
             }
           }
         },
@@ -48,15 +54,18 @@
             "element": "string",
             "content": "object.name-member"
           },
-          "links": [
-            {
-              "element": "link",
-              "content": {
-                "relation": "uri-fragment",
-                "href": "object/name-member"
+          "links": {
+            "element": "array",
+            "content": [
+              {
+                "element": "link",
+                "content": {
+                  "relation": "uri-fragment",
+                  "href": "object/name-member"
+                }
               }
-            }
-          ]
+            ]
+          }
         }
       },
       {
@@ -70,15 +79,18 @@
                 "element": "string",
                 "content": "object.tags-key"
               },
-              "links": [
-                {
-                  "element": "link",
-                  "content": {
-                    "relation": "uri-fragment",
-                    "href": "object/tags-key"
+              "links": {
+                "element": "array",
+                "content": [
+                  {
+                    "element": "link",
+                    "content": {
+                      "relation": "uri-fragment",
+                      "href": "object/tags-key"
+                    }
                   }
-                }
-              ]
+                ]
+              }
             }
           },
           "value": {
@@ -98,15 +110,18 @@
                             "element": "string",
                             "content": "object.tags.0.name-key"
                           },
-                          "links": [
-                            {
-                              "element": "link",
-                              "content": {
-                                "relation": "uri-fragment",
-                                "href": "object/tags/0/name-key"
+                          "links": {
+                            "element": "array",
+                            "content": [
+                              {
+                                "element": "link",
+                                "content": {
+                                  "relation": "uri-fragment",
+                                  "href": "object/tags/0/name-key"
+                                }
                               }
-                            }
-                          ]
+                            ]
+                          }
                         }
                       },
                       "value": {
@@ -116,15 +131,18 @@
                             "element": "string",
                             "content": "object.tags.0.name"
                           },
-                          "links": [
-                            {
-                              "element": "link",
-                              "content": {
-                                "relation": "uri-fragment",
-                                "href": "object/tags/0/name"
+                          "links": {
+                            "element": "array",
+                            "content": [
+                              {
+                                "element": "link",
+                                "content": {
+                                  "relation": "uri-fragment",
+                                  "href": "object/tags/0/name"
+                                }
                               }
-                            }
-                          ]
+                            ]
+                          }
                         }
                       }
                     },
@@ -133,15 +151,18 @@
                         "element": "string",
                         "content": "object.tags.0.name-member"
                       },
-                      "links": [
-                        {
-                          "element": "link",
-                          "content": {
-                            "relation": "uri-fragment",
-                            "href": "object/tags/0/name-member"
+                      "links": {
+                        "element": "array",
+                        "content": [
+                          {
+                            "element": "link",
+                            "content": {
+                              "relation": "uri-fragment",
+                              "href": "object/tags/0/name-member"
+                            }
                           }
-                        }
-                      ]
+                        ]
+                      }
                     }
                   },
                   {
@@ -155,15 +176,18 @@
                             "element": "string",
                             "content": "object.tags.0.count-key"
                           },
-                          "links": [
-                            {
-                              "element": "link",
-                              "content": {
-                                "relation": "uri-fragment",
-                                "href": "object/tags/0/count-key"
+                          "links": {
+                            "element": "array",
+                            "content": [
+                              {
+                                "element": "link",
+                                "content": {
+                                  "relation": "uri-fragment",
+                                  "href": "object/tags/0/count-key"
+                                }
                               }
-                            }
-                          ]
+                            ]
+                          }
                         }
                       },
                       "value": {
@@ -173,15 +197,18 @@
                             "element": "string",
                             "content": "object.tags.0.count"
                           },
-                          "links": [
-                            {
-                              "element": "link",
-                              "content": {
-                                "relation": "uri-fragment",
-                                "href": "object/tags/0/count"
+                          "links": {
+                            "element": "array",
+                            "content": [
+                              {
+                                "element": "link",
+                                "content": {
+                                  "relation": "uri-fragment",
+                                  "href": "object/tags/0/count"
+                                }
                               }
-                            }
-                          ]
+                            ]
+                          }
                         }
                       }
                     },
@@ -190,15 +217,18 @@
                         "element": "string",
                         "content": "object.tags.0.count-member"
                       },
-                      "links": [
-                        {
-                          "element": "link",
-                          "content": {
-                            "relation": "uri-fragment",
-                            "href": "object/tags/0/count-member"
+                      "links": {
+                        "element": "array",
+                        "content": [
+                          {
+                            "element": "link",
+                            "content": {
+                              "relation": "uri-fragment",
+                              "href": "object/tags/0/count-member"
+                            }
                           }
-                        }
-                      ]
+                        ]
+                      }
                     }
                   }
                 ],
@@ -207,15 +237,18 @@
                     "element": "string",
                     "content": "object.tags.0"
                   },
-                  "links": [
-                    {
-                      "element": "link",
-                      "content": {
-                        "relation": "uri-fragment",
-                        "href": "object/tags/0"
+                  "links": {
+                    "element": "array",
+                    "content": [
+                      {
+                        "element": "link",
+                        "content": {
+                          "relation": "uri-fragment",
+                          "href": "object/tags/0"
+                        }
                       }
-                    }
-                  ]
+                    ]
+                  }
                 }
               }
             ],
@@ -224,15 +257,18 @@
                 "element": "string",
                 "content": "object.tags"
               },
-              "links": [
-                {
-                  "element": "link",
-                  "content": {
-                    "relation": "uri-fragment",
-                    "href": "object/tags"
+              "links": {
+                "element": "array",
+                "content": [
+                  {
+                    "element": "link",
+                    "content": {
+                      "relation": "uri-fragment",
+                      "href": "object/tags"
+                    }
                   }
-                }
-              ]
+                ]
+              }
             }
           }
         },
@@ -241,15 +277,18 @@
             "element": "string",
             "content": "object.tags-member"
           },
-          "links": [
-            {
-              "element": "link",
-              "content": {
-                "relation": "uri-fragment",
-                "href": "object/tags-member"
+          "links": {
+            "element": "array",
+            "content": [
+              {
+                "element": "link",
+                "content": {
+                  "relation": "uri-fragment",
+                  "href": "object/tags-member"
+                }
               }
-            }
-          ]
+            ]
+          }
         }
       }
     ],
@@ -258,15 +297,18 @@
         "element": "string",
         "content": "object"
       },
-      "links": [
-        {
-          "element": "link",
-          "content": {
-            "relation": "uri-fragment",
-            "href": "object"
+      "links": {
+        "element": "array",
+        "content": [
+          {
+            "element": "link",
+            "content": {
+              "relation": "uri-fragment",
+              "href": "object"
+            }
           }
-        }
-      ]
+        ]
+      }
     }
   }
 ]

--- a/test/output/objects.json
+++ b/test/output/objects.json
@@ -18,7 +18,7 @@
                 "content": [
                   {
                     "element": "link",
-                    "content": {
+                    "attributes": {
                       "relation": "uri-fragment",
                       "href": "object/name-key"
                     }
@@ -39,7 +39,7 @@
                 "content": [
                   {
                     "element": "link",
-                    "content": {
+                    "attributes": {
                       "relation": "uri-fragment",
                       "href": "object/name"
                     }
@@ -59,7 +59,7 @@
             "content": [
               {
                 "element": "link",
-                "content": {
+                "attributes": {
                   "relation": "uri-fragment",
                   "href": "object/name-member"
                 }
@@ -84,7 +84,7 @@
                 "content": [
                   {
                     "element": "link",
-                    "content": {
+                    "attributes": {
                       "relation": "uri-fragment",
                       "href": "object/tags-key"
                     }
@@ -115,7 +115,7 @@
                             "content": [
                               {
                                 "element": "link",
-                                "content": {
+                                "attributes": {
                                   "relation": "uri-fragment",
                                   "href": "object/tags/0/name-key"
                                 }
@@ -136,7 +136,7 @@
                             "content": [
                               {
                                 "element": "link",
-                                "content": {
+                                "attributes": {
                                   "relation": "uri-fragment",
                                   "href": "object/tags/0/name"
                                 }
@@ -156,7 +156,7 @@
                         "content": [
                           {
                             "element": "link",
-                            "content": {
+                            "attributes": {
                               "relation": "uri-fragment",
                               "href": "object/tags/0/name-member"
                             }
@@ -181,7 +181,7 @@
                             "content": [
                               {
                                 "element": "link",
-                                "content": {
+                                "attributes": {
                                   "relation": "uri-fragment",
                                   "href": "object/tags/0/count-key"
                                 }
@@ -202,7 +202,7 @@
                             "content": [
                               {
                                 "element": "link",
-                                "content": {
+                                "attributes": {
                                   "relation": "uri-fragment",
                                   "href": "object/tags/0/count"
                                 }
@@ -222,7 +222,7 @@
                         "content": [
                           {
                             "element": "link",
-                            "content": {
+                            "attributes": {
                               "relation": "uri-fragment",
                               "href": "object/tags/0/count-member"
                             }
@@ -242,7 +242,7 @@
                     "content": [
                       {
                         "element": "link",
-                        "content": {
+                        "attributes": {
                           "relation": "uri-fragment",
                           "href": "object/tags/0"
                         }
@@ -262,7 +262,7 @@
                 "content": [
                   {
                     "element": "link",
-                    "content": {
+                    "attributes": {
                       "relation": "uri-fragment",
                       "href": "object/tags"
                     }
@@ -282,7 +282,7 @@
             "content": [
               {
                 "element": "link",
-                "content": {
+                "attributes": {
                   "relation": "uri-fragment",
                   "href": "object/tags-member"
                 }
@@ -302,7 +302,7 @@
         "content": [
           {
             "element": "link",
-            "content": {
+            "attributes": {
               "relation": "uri-fragment",
               "href": "object"
             }

--- a/test/output/objects.json
+++ b/test/output/objects.json
@@ -9,7 +9,10 @@
             "element": "string",
             "content": "name",
             "meta": {
-              "id": "object.name-key",
+              "id": {
+                "element": "string",
+                "content": "object.name-key"
+              },
               "links": [
                 {
                   "element": "link",
@@ -24,7 +27,10 @@
           "value": {
             "element": "string",
             "meta": {
-              "id": "object.name",
+              "id": {
+                "element": "string",
+                "content": "object.name"
+              },
               "links": [
                 {
                   "element": "link",
@@ -38,7 +44,10 @@
           }
         },
         "meta": {
-          "id": "object.name-member",
+          "id": {
+            "element": "string",
+            "content": "object.name-member"
+          },
           "links": [
             {
               "element": "link",
@@ -57,7 +66,10 @@
             "element": "string",
             "content": "tags",
             "meta": {
-              "id": "object.tags-key",
+              "id": {
+                "element": "string",
+                "content": "object.tags-key"
+              },
               "links": [
                 {
                   "element": "link",
@@ -82,7 +94,10 @@
                         "element": "string",
                         "content": "name",
                         "meta": {
-                          "id": "object.tags.0.name-key",
+                          "id": {
+                            "element": "string",
+                            "content": "object.tags.0.name-key"
+                          },
                           "links": [
                             {
                               "element": "link",
@@ -97,7 +112,10 @@
                       "value": {
                         "element": "string",
                         "meta": {
-                          "id": "object.tags.0.name",
+                          "id": {
+                            "element": "string",
+                            "content": "object.tags.0.name"
+                          },
                           "links": [
                             {
                               "element": "link",
@@ -111,7 +129,10 @@
                       }
                     },
                     "meta": {
-                      "id": "object.tags.0.name-member",
+                      "id": {
+                        "element": "string",
+                        "content": "object.tags.0.name-member"
+                      },
                       "links": [
                         {
                           "element": "link",
@@ -130,7 +151,10 @@
                         "element": "string",
                         "content": "count",
                         "meta": {
-                          "id": "object.tags.0.count-key",
+                          "id": {
+                            "element": "string",
+                            "content": "object.tags.0.count-key"
+                          },
                           "links": [
                             {
                               "element": "link",
@@ -145,7 +169,10 @@
                       "value": {
                         "element": "number",
                         "meta": {
-                          "id": "object.tags.0.count",
+                          "id": {
+                            "element": "string",
+                            "content": "object.tags.0.count"
+                          },
                           "links": [
                             {
                               "element": "link",
@@ -159,7 +186,10 @@
                       }
                     },
                     "meta": {
-                      "id": "object.tags.0.count-member",
+                      "id": {
+                        "element": "string",
+                        "content": "object.tags.0.count-member"
+                      },
                       "links": [
                         {
                           "element": "link",
@@ -173,7 +203,10 @@
                   }
                 ],
                 "meta": {
-                  "id": "object.tags.0",
+                  "id": {
+                    "element": "string",
+                    "content": "object.tags.0"
+                  },
                   "links": [
                     {
                       "element": "link",
@@ -187,7 +220,10 @@
               }
             ],
             "meta": {
-              "id": "object.tags",
+              "id": {
+                "element": "string",
+                "content": "object.tags"
+              },
               "links": [
                 {
                   "element": "link",
@@ -201,7 +237,10 @@
           }
         },
         "meta": {
-          "id": "object.tags-member",
+          "id": {
+            "element": "string",
+            "content": "object.tags-member"
+          },
           "links": [
             {
               "element": "link",
@@ -215,7 +254,10 @@
       }
     ],
     "meta": {
-      "id": "object",
+      "id": {
+        "element": "string",
+        "content": "object"
+      },
       "links": [
         {
           "element": "link",

--- a/test/output/references.json
+++ b/test/output/references.json
@@ -6,15 +6,18 @@
         "element": "string",
         "content": "MyObject"
       },
-      "links": [
-        {
-          "element": "link",
-          "content": {
-            "relation": "uri-fragment",
-            "href": "myobject"
+      "links": {
+        "element": "array",
+        "content": [
+          {
+            "element": "link",
+            "content": {
+              "relation": "uri-fragment",
+              "href": "myobject"
+            }
           }
-        }
-      ]
+        ]
+      }
     },
     "content": [
       {
@@ -28,15 +31,18 @@
                 "element": "string",
                 "content": "MyObject.name-key"
               },
-              "links": [
-                {
-                  "element": "link",
-                  "content": {
-                    "relation": "uri-fragment",
-                    "href": "myobject/name-key"
+              "links": {
+                "element": "array",
+                "content": [
+                  {
+                    "element": "link",
+                    "content": {
+                      "relation": "uri-fragment",
+                      "href": "myobject/name-key"
+                    }
                   }
-                }
-              ]
+                ]
+              }
             }
           },
           "value": {
@@ -46,15 +52,18 @@
                 "element": "string",
                 "content": "MyObject.name"
               },
-              "links": [
-                {
-                  "element": "link",
-                  "content": {
-                    "relation": "uri-fragment",
-                    "href": "myobject/name"
+              "links": {
+                "element": "array",
+                "content": [
+                  {
+                    "element": "link",
+                    "content": {
+                      "relation": "uri-fragment",
+                      "href": "myobject/name"
+                    }
                   }
-                }
-              ]
+                ]
+              }
             }
           }
         },
@@ -63,15 +72,18 @@
             "element": "string",
             "content": "MyObject.name-member"
           },
-          "links": [
-            {
-              "element": "link",
-              "content": {
-                "relation": "uri-fragment",
-                "href": "myobject/name-member"
+          "links": {
+            "element": "array",
+            "content": [
+              {
+                "element": "link",
+                "content": {
+                  "relation": "uri-fragment",
+                  "href": "myobject/name-member"
+                }
               }
-            }
-          ]
+            ]
+          }
         }
       },
       {
@@ -89,15 +101,18 @@
         "element": "string",
         "content": "SpecialString"
       },
-      "links": [
-        {
-          "element": "link",
-          "content": {
-            "relation": "uri-fragment",
-            "href": "specialstring"
+      "links": {
+        "element": "array",
+        "content": [
+          {
+            "element": "link",
+            "content": {
+              "relation": "uri-fragment",
+              "href": "specialstring"
+            }
           }
-        }
-      ]
+        ]
+      }
     },
     "content": "I am special"
   },
@@ -108,15 +123,18 @@
         "element": "string",
         "content": "IncludedObject"
       },
-      "links": [
-        {
-          "element": "link",
-          "content": {
-            "relation": "uri-fragment",
-            "href": "includedobject"
+      "links": {
+        "element": "array",
+        "content": [
+          {
+            "element": "link",
+            "content": {
+              "relation": "uri-fragment",
+              "href": "includedobject"
+            }
           }
-        }
-      ]
+        ]
+      }
     },
     "content": [
       {
@@ -130,15 +148,18 @@
                 "element": "string",
                 "content": "IncludedObject.address-key"
               },
-              "links": [
-                {
-                  "element": "link",
-                  "content": {
-                    "relation": "uri-fragment",
-                    "href": "includedobject/address-key"
+              "links": {
+                "element": "array",
+                "content": [
+                  {
+                    "element": "link",
+                    "content": {
+                      "relation": "uri-fragment",
+                      "href": "includedobject/address-key"
+                    }
                   }
-                }
-              ]
+                ]
+              }
             }
           },
           "value": {
@@ -148,15 +169,18 @@
                 "element": "string",
                 "content": "IncludedObject.address"
               },
-              "links": [
-                {
-                  "element": "link",
-                  "content": {
-                    "relation": "uri-fragment",
-                    "href": "includedobject/address"
+              "links": {
+                "element": "array",
+                "content": [
+                  {
+                    "element": "link",
+                    "content": {
+                      "relation": "uri-fragment",
+                      "href": "includedobject/address"
+                    }
                   }
-                }
-              ]
+                ]
+              }
             }
           }
         },
@@ -165,15 +189,18 @@
             "element": "string",
             "content": "IncludedObject.address-member"
           },
-          "links": [
-            {
-              "element": "link",
-              "content": {
-                "relation": "uri-fragment",
-                "href": "includedobject/address-member"
+          "links": {
+            "element": "array",
+            "content": [
+              {
+                "element": "link",
+                "content": {
+                  "relation": "uri-fragment",
+                  "href": "includedobject/address-member"
+                }
               }
-            }
-          ]
+            ]
+          }
         }
       }
     ]

--- a/test/output/references.json
+++ b/test/output/references.json
@@ -2,7 +2,10 @@
   {
     "element": "object",
     "meta": {
-      "id": "MyObject",
+      "id": {
+        "element": "string",
+        "content": "MyObject"
+      },
       "links": [
         {
           "element": "link",
@@ -21,7 +24,10 @@
             "element": "string",
             "content": "name",
             "meta": {
-              "id": "MyObject.name-key",
+              "id": {
+                "element": "string",
+                "content": "MyObject.name-key"
+              },
               "links": [
                 {
                   "element": "link",
@@ -36,7 +42,10 @@
           "value": {
             "element": "SpecialString",
             "meta": {
-              "id": "MyObject.name",
+              "id": {
+                "element": "string",
+                "content": "MyObject.name"
+              },
               "links": [
                 {
                   "element": "link",
@@ -50,7 +59,10 @@
           }
         },
         "meta": {
-          "id": "MyObject.name-member",
+          "id": {
+            "element": "string",
+            "content": "MyObject.name-member"
+          },
           "links": [
             {
               "element": "link",
@@ -73,7 +85,10 @@
   {
     "element": "string",
     "meta": {
-      "id": "SpecialString",
+      "id": {
+        "element": "string",
+        "content": "SpecialString"
+      },
       "links": [
         {
           "element": "link",
@@ -89,7 +104,10 @@
   {
     "element": "object",
     "meta": {
-      "id": "IncludedObject",
+      "id": {
+        "element": "string",
+        "content": "IncludedObject"
+      },
       "links": [
         {
           "element": "link",
@@ -108,7 +126,10 @@
             "element": "string",
             "content": "address",
             "meta": {
-              "id": "IncludedObject.address-key",
+              "id": {
+                "element": "string",
+                "content": "IncludedObject.address-key"
+              },
               "links": [
                 {
                   "element": "link",
@@ -123,7 +144,10 @@
           "value": {
             "element": "string",
             "meta": {
-              "id": "IncludedObject.address",
+              "id": {
+                "element": "string",
+                "content": "IncludedObject.address"
+              },
               "links": [
                 {
                   "element": "link",
@@ -137,7 +161,10 @@
           }
         },
         "meta": {
-          "id": "IncludedObject.address-member",
+          "id": {
+            "element": "string",
+            "content": "IncludedObject.address-member"
+          },
           "links": [
             {
               "element": "link",

--- a/test/output/references.json
+++ b/test/output/references.json
@@ -11,7 +11,7 @@
         "content": [
           {
             "element": "link",
-            "content": {
+            "attributes": {
               "relation": "uri-fragment",
               "href": "myobject"
             }
@@ -36,7 +36,7 @@
                 "content": [
                   {
                     "element": "link",
-                    "content": {
+                    "attributes": {
                       "relation": "uri-fragment",
                       "href": "myobject/name-key"
                     }
@@ -57,7 +57,7 @@
                 "content": [
                   {
                     "element": "link",
-                    "content": {
+                    "attributes": {
                       "relation": "uri-fragment",
                       "href": "myobject/name"
                     }
@@ -77,7 +77,7 @@
             "content": [
               {
                 "element": "link",
-                "content": {
+                "attributes": {
                   "relation": "uri-fragment",
                   "href": "myobject/name-member"
                 }
@@ -106,7 +106,7 @@
         "content": [
           {
             "element": "link",
-            "content": {
+            "attributes": {
               "relation": "uri-fragment",
               "href": "specialstring"
             }
@@ -128,7 +128,7 @@
         "content": [
           {
             "element": "link",
-            "content": {
+            "attributes": {
               "relation": "uri-fragment",
               "href": "includedobject"
             }
@@ -153,7 +153,7 @@
                 "content": [
                   {
                     "element": "link",
-                    "content": {
+                    "attributes": {
                       "relation": "uri-fragment",
                       "href": "includedobject/address-key"
                     }
@@ -174,7 +174,7 @@
                 "content": [
                   {
                     "element": "link",
-                    "content": {
+                    "attributes": {
                       "relation": "uri-fragment",
                       "href": "includedobject/address"
                     }
@@ -194,7 +194,7 @@
             "content": [
               {
                 "element": "link",
-                "content": {
+                "attributes": {
                   "relation": "uri-fragment",
                   "href": "includedobject/address-member"
                 }

--- a/test/output/simple-types.json
+++ b/test/output/simple-types.json
@@ -3,7 +3,10 @@
     "element": "boolean",
     "content": true,
     "meta": {
-      "id": "boolean",
+      "id": {
+        "element": "string",
+        "content": "boolean"
+      },
       "links": [
         {
           "element": "link",
@@ -19,7 +22,10 @@
     "element": "string",
     "content": "test",
     "meta": {
-      "id": "string",
+      "id": {
+        "element": "string",
+        "content": "string"
+      },
       "links": [
         {
           "element": "link",
@@ -35,7 +41,10 @@
     "element": "string",
     "content": "another test",
     "meta": {
-      "id": "string-2",
+      "id": {
+        "element": "string",
+        "content": "string-2"
+      },
       "links": [
         {
           "element": "link",
@@ -51,7 +60,10 @@
     "element": "number",
     "content": 123,
     "meta": {
-      "id": "number",
+      "id": {
+        "element": "string",
+        "content": "number"
+      },
       "links": [
         {
           "element": "link",
@@ -67,7 +79,10 @@
     "element": "number",
     "content": 456,
     "meta": {
-      "id": "number-2",
+      "id": {
+        "element": "string",
+        "content": "number-2"
+      },
       "links": [
         {
           "element": "link",

--- a/test/output/simple-types.json
+++ b/test/output/simple-types.json
@@ -12,7 +12,7 @@
         "content": [
           {
             "element": "link",
-            "content": {
+            "attributes": {
               "relation": "uri-fragment",
               "href": "boolean"
             }
@@ -34,7 +34,7 @@
         "content": [
           {
             "element": "link",
-            "content": {
+            "attributes": {
               "relation": "uri-fragment",
               "href": "string"
             }
@@ -56,7 +56,7 @@
         "content": [
           {
             "element": "link",
-            "content": {
+            "attributes": {
               "relation": "uri-fragment",
               "href": "string-2"
             }
@@ -78,7 +78,7 @@
         "content": [
           {
             "element": "link",
-            "content": {
+            "attributes": {
               "relation": "uri-fragment",
               "href": "number"
             }
@@ -100,7 +100,7 @@
         "content": [
           {
             "element": "link",
-            "content": {
+            "attributes": {
               "relation": "uri-fragment",
               "href": "number-2"
             }

--- a/test/output/simple-types.json
+++ b/test/output/simple-types.json
@@ -7,15 +7,18 @@
         "element": "string",
         "content": "boolean"
       },
-      "links": [
-        {
-          "element": "link",
-          "content": {
-            "relation": "uri-fragment",
-            "href": "boolean"
+      "links": {
+        "element": "array",
+        "content": [
+          {
+            "element": "link",
+            "content": {
+              "relation": "uri-fragment",
+              "href": "boolean"
+            }
           }
-        }
-      ]
+        ]
+      }
     }
   },
   {
@@ -26,15 +29,18 @@
         "element": "string",
         "content": "string"
       },
-      "links": [
-        {
-          "element": "link",
-          "content": {
-            "relation": "uri-fragment",
-            "href": "string"
+      "links": {
+        "element": "array",
+        "content": [
+          {
+            "element": "link",
+            "content": {
+              "relation": "uri-fragment",
+              "href": "string"
+            }
           }
-        }
-      ]
+        ]
+      }
     }
   },
   {
@@ -45,15 +51,18 @@
         "element": "string",
         "content": "string-2"
       },
-      "links": [
-        {
-          "element": "link",
-          "content": {
-            "relation": "uri-fragment",
-            "href": "string-2"
+      "links": {
+        "element": "array",
+        "content": [
+          {
+            "element": "link",
+            "content": {
+              "relation": "uri-fragment",
+              "href": "string-2"
+            }
           }
-        }
-      ]
+        ]
+      }
     }
   },
   {
@@ -64,15 +73,18 @@
         "element": "string",
         "content": "number"
       },
-      "links": [
-        {
-          "element": "link",
-          "content": {
-            "relation": "uri-fragment",
-            "href": "number"
+      "links": {
+        "element": "array",
+        "content": [
+          {
+            "element": "link",
+            "content": {
+              "relation": "uri-fragment",
+              "href": "number"
+            }
           }
-        }
-      ]
+        ]
+      }
     }
   },
   {
@@ -83,15 +95,18 @@
         "element": "string",
         "content": "number-2"
       },
-      "links": [
-        {
-          "element": "link",
-          "content": {
-            "relation": "uri-fragment",
-            "href": "number-2"
+      "links": {
+        "element": "array",
+        "content": [
+          {
+            "element": "link",
+            "content": {
+              "relation": "uri-fragment",
+              "href": "number-2"
+            }
           }
-        }
-      ]
+        ]
+      }
     }
   }
 ]


### PR DESCRIPTION
**DO NOT MERGE**

This pull request adds support for expanded refract serialisation. Let's walk though commit-by-commit:

- 575e52bbc5799e19831df6baf5cda7c9bc045dac: Fixes element ID generation to utilise Refracted classes. Before refracted classes have been ignored.
- 3c64dbc446e1db47c27839d7f3ec3e347e1ef34e: Fix support for handling Refracted element IDs, and now Abagnale will **always** produce Refracted element IDs.
- 360e1b568cdead9640b229ef7de6c361fb621c2a Makes it so that Abagnale will not remove meta/attributes in there given element IDs, previously this information would be removed by Abagnale. 
- 360e1b568cdead9640b229ef7de6c361fb621c2a  also prevents "uniquifying" given element IDs, we shouldn't mess with given element IDs as we can break existing references to these element IDs.
- d62a14ae755c0cc0c5441724d32fd5cd51ab1409 adds support for handling Refracted meta links array element. Previously this would cause undefined behaviour when "pushing" a link element into an object.
- 222168e246bfe810d1c8db2f6b70f11bce56e0a7 Changes so that Abagnale will never create an array directly in links, but instead use an array element. Support for an array being given under links is retained.

**DO NOT MERGE**

*Various PRs will be created across multiple libraries before this one is ready to be merged.*